### PR TITLE
Default divider prop was said to be false in the README

### DIFF
--- a/components/src/core/hero/hero-banner.component.ts
+++ b/components/src/core/hero/hero-banner.component.ts
@@ -11,5 +11,5 @@ import { Component, Input } from '@angular/core';
     styleUrls: ['./hero-banner.component.scss'],
 })
 export class HeroBannerComponent {
-    @Input() divider = true;
+    @Input() divider = false;
 }

--- a/demos/storybook/stories/ hero/within-a-banner.stories.ts
+++ b/demos/storybook/stories/ hero/within-a-banner.stories.ts
@@ -3,7 +3,7 @@ import * as Colors from '@pxblue/colors';
 
 export const withinBanner = (): any => ({
     template: `
-          <pxb-hero-banner [divider]="false">
+          <pxb-hero-banner>
              <pxb-hero *ngIf="count > 0" [label]="'Health'" [value]="96" [units]="'/100'">
                 <i primary [style.color]="green" class="pxb-grade_a"></i>
              </pxb-hero>


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- README said the default `divider` prop in the HeroBanner was supposed to be false; it was `true` so I changed it back to `false`.
