### PR TITLE
Feature/comp tweaks

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -14,8 +14,7 @@
     "lint:fix": "eslint \"src/**/**.ts\" --fix"
   },
   "peerDependencies": {
-    "@angular/material": "^8.2.3",
-    "@pxblue/colors": "^2.0.0"
+    "@angular/material": "^8.2.3"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^0.803.23",
@@ -31,7 +30,6 @@
     "@angular/material": "^8.2.3",
     "@angular/platform-browser": "~8.2.2",
     "@angular/platform-browser-dynamic": "~8.2.2",
-    "@pxblue/colors": "^2.0.0",
     "@pxblue/eslint-config": "^1.1.4",
     "@pxblue/ng-progress-icons": "^1.1.3",
     "@pxblue/prettier-config": "^1.0.2",

--- a/components/src/core/channel-value/channel-value.component.scss
+++ b/components/src/core/channel-value/channel-value.component.scss
@@ -1,33 +1,38 @@
 :host {
     display: inline-flex;
 }
-.value-wrapper {
+
+.pxb-channel-value {
     display: flex;
-}
-.text {
-    font-size: inherit;
     line-height: 1.2;
-    letter-spacing: 0;
-    margin: 0;
-}
-.units {
-    font-weight: 300;
-}
-.value {
-    font-weight: 600;
-}
-.icon {
-    font-size: inherit;
-    display: block;
-    margin-right: 4px;
-    &:empty {
-        display: none;
+
+    .pxb-channel-value-text {
+        font-size: inherit;
+        letter-spacing: 0;
+        margin: 0;
     }
-    ::ng-deep mat-icon {
+
+    .pxb-channel-value-units {
+        font-weight: 300;
+    }
+
+    .pxb-channel-value-value {
+        font-weight: 600;
+    }
+
+    .pxb-channel-value-icon {
+        font-size: inherit;
         display: block;
-        width: 100%;
-        height: 100%;
-        font-size: 100%;
-        line-height: 1.2;
+        margin-right: 4px;
+        &:empty {
+            display: none;
+        }
+        * {
+            display: block;
+            width: 100%;
+            height: 100%;
+            font-size: 100%;
+            line-height: 1.2;
+        }
     }
 }

--- a/components/src/core/channel-value/channel-value.component.spec.ts
+++ b/components/src/core/channel-value/channel-value.component.spec.ts
@@ -18,7 +18,7 @@ describe('ChannelValueComponent', () => {
         component = fixture.componentInstance;
     });
 
-    it('should create', () => {
+    it('should initialize', () => {
         fixture.detectChanges();
         expect(component).toBeTruthy();
     });

--- a/components/src/core/channel-value/channel-value.component.spec.ts
+++ b/components/src/core/channel-value/channel-value.component.spec.ts
@@ -1,7 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ChannelValueComponent } from './channel-value.component';
-import {count} from "../../utils/test-utils";
-import {ChannelValueModule} from "./channel-value.module";
+import { count } from '../../utils/test-utils';
+import { ChannelValueModule } from './channel-value.module';
 
 describe('ChannelValueComponent', () => {
     let component: ChannelValueComponent;
@@ -31,7 +31,7 @@ describe('ChannelValueComponent', () => {
             '.pxb-channel-value',
             '.pxb-channel-value-units',
             '.pxb-channel-value-icon',
-            '.pxb-channel-value-value'
+            '.pxb-channel-value-value',
         ];
         for (const className of classList) {
             count(fixture, className);

--- a/components/src/core/channel-value/channel-value.component.spec.ts
+++ b/components/src/core/channel-value/channel-value.component.spec.ts
@@ -1,5 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ChannelValueComponent } from './channel-value.component';
+import {count} from "../../utils/test-utils";
+import {ChannelValueModule} from "./channel-value.module";
 
 describe('ChannelValueComponent', () => {
     let component: ChannelValueComponent;
@@ -7,17 +9,33 @@ describe('ChannelValueComponent', () => {
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({
-            declarations: [ChannelValueComponent],
+            imports: [ChannelValueModule],
         }).compileComponents();
     }));
 
     beforeEach(() => {
         fixture = TestBed.createComponent(ChannelValueComponent);
         component = fixture.componentInstance;
-        fixture.detectChanges();
     });
 
     it('should create', () => {
+        fixture.detectChanges();
         expect(component).toBeTruthy();
+    });
+
+    it('should enforce class naming conventions', () => {
+        component.value = '123';
+        component.units = 'hz';
+        fixture.detectChanges();
+        const classList = [
+            '.pxb-channel-value',
+            '.pxb-channel-value-units',
+            '.pxb-channel-value-icon',
+            '.pxb-channel-value-value'
+        ];
+        for (const className of classList) {
+            count(fixture, className);
+        }
+        count(fixture, '.pxb-channel-value-text', 2);
     });
 });

--- a/components/src/core/channel-value/channel-value.component.ts
+++ b/components/src/core/channel-value/channel-value.component.ts
@@ -1,15 +1,17 @@
-import { Component, Input } from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input, ViewEncapsulation} from '@angular/core';
 
 @Component({
     selector: 'pxb-channel-value',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    encapsulation: ViewEncapsulation.None,
     template: `
-        <span class="value-wrapper" [style.color]="color" [style.fontSize.px]="fontSize">
-            <span class="icon">
+        <span class="pxb-channel-value" [style.color]="color" [style.fontSize.px]="fontSize">
+            <span class="pxb-channel-value-icon">
                 <ng-content></ng-content>
             </span>
-            <h5 *ngIf="units && prefix" class="text units">{{ units }}</h5>
-            <h5 *ngIf="value" class="text value">{{ value }}</h5>
-            <h5 *ngIf="units && !prefix" class="text units">{{ units }}</h5>
+            <div *ngIf="units && prefix" class="pxb-channel-value-text pxb-channel-value-units">{{ units }}</div>
+            <div *ngIf="value" class="pxb-channel-value-text pxb-channel-value-value">{{ value }}</div>
+            <div *ngIf="units && !prefix" class="pxb-channel-value-text pxb-channel-value-units">{{ units }}</div>
         </span>
     `,
     styleUrls: ['./channel-value.component.scss'],
@@ -19,5 +21,5 @@ export class ChannelValueComponent {
     @Input() units: string;
     @Input() fontSize = 'inherit';
     @Input() prefix = false;
-    @Input() color = 'inherit';
+    @Input() color;
 }

--- a/components/src/core/channel-value/channel-value.component.ts
+++ b/components/src/core/channel-value/channel-value.component.ts
@@ -1,4 +1,4 @@
-import {ChangeDetectionStrategy, Component, Input, ViewEncapsulation} from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
 
 @Component({
     selector: 'pxb-channel-value',

--- a/components/src/core/empty-state/empty-state.component.html
+++ b/components/src/core/empty-state/empty-state.component.html
@@ -1,9 +1,9 @@
-<div class="container" [style.color]="Colors.gray[500]">
-    <div style="line-height: 1">
+<div class="pxb-empty-state">
+    <div class="pxb-empty-state-empty-icon-wrapper">
         <ng-content select="[empty-icon]"></ng-content>
     </div>
-    <h2>{{ title }}</h2>
-    <h4 *ngIf="description" [style.color]="Colors.blue[500]">{{ description }}</h4>
+    <h2 class="pxb-empty-state-title">{{ title }}</h2>
+    <h4 *ngIf="description" class="pxb-empty-state-description">{{ description }}</h4>
     <div>
         <ng-content select="[actions]"></ng-content>
     </div>

--- a/components/src/core/empty-state/empty-state.component.scss
+++ b/components/src/core/empty-state/empty-state.component.scss
@@ -14,7 +14,8 @@
         margin-bottom: 0;
     }
 
-    .pxb-empty-state-title, .pxb-empty-state-description {
+    .pxb-empty-state-title,
+    .pxb-empty-state-description {
         text-align: center;
     }
 

--- a/components/src/core/empty-state/empty-state.component.scss
+++ b/components/src/core/empty-state/empty-state.component.scss
@@ -5,21 +5,27 @@
     justify-content: center;
 }
 
-:host ::ng-deep [empty-icon] {
-    display: block;
-    font-size: 100px;
-    height: 100%;
-    width: 100%;
-    text-align: center;
-}
-
-.container {
+.pxb-empty-state {
     display: flex;
     flex-direction: column;
     align-items: center;
-}
 
-h2,
-h4 {
-    text-align: center;
+    .pxb-empty-state-title {
+        margin-bottom: 0;
+    }
+
+    .pxb-empty-state-title, .pxb-empty-state-description {
+        text-align: center;
+    }
+
+    .pxb-empty-state-empty-icon-wrapper {
+        line-height: 1;
+        > * {
+            display: block;
+            font-size: 100px;
+            height: 100%;
+            width: 100%;
+            text-align: center;
+        }
+    }
 }

--- a/components/src/core/empty-state/empty-state.component.spec.ts
+++ b/components/src/core/empty-state/empty-state.component.spec.ts
@@ -1,7 +1,9 @@
-import { async, TestBed } from '@angular/core/testing';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import { Component } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { EmptyStateComponent } from './empty-state.component';
+import {count} from "../../utils/test-utils";
+import {EmptyStateModule} from "./empty-state.module";
 
 /** Test component that contains an MatButton. */
 @Component({
@@ -20,77 +22,82 @@ import { EmptyStateComponent } from './empty-state.component';
 class TestEmpty {}
 
 describe('Empty State Component', () => {
+
+    let fixture: ComponentFixture<EmptyStateComponent>;
+    let component: EmptyStateComponent;
+
     beforeEach(async(() => {
         TestBed.configureTestingModule({
-            imports: [],
-            declarations: [EmptyStateComponent, TestEmpty],
-        });
-
-        TestBed.compileComponents();
+            imports: [EmptyStateModule],
+            declarations: [TestEmpty],
+        }).compileComponents();
     }));
 
-    // Title Check
-    it('should show title when supplied', () => {
-        const fixture = TestBed.createComponent(EmptyStateComponent);
-
-        const testComponent = fixture.debugElement.componentInstance;
-        const titleElement = fixture.debugElement.query(By.css('h2'));
-
-        testComponent.title = 'TEST';
-        fixture.detectChanges();
-        expect(titleElement.nativeElement.innerHTML).toBe('TEST');
-
-        testComponent.title = '';
-        fixture.detectChanges();
-        expect(titleElement.nativeElement.innerHTML).toBe('');
-
-        testComponent.title = null;
-        fixture.detectChanges();
-
-        expect(titleElement.nativeElement.innerHTML).toBe('');
+    beforeEach(() => {
+        fixture = TestBed.createComponent(EmptyStateComponent);
+        component = fixture.componentInstance;
     });
 
-    // Description Check
+    it('should show title when supplied', () => {
+        component.title = 'title';
+        fixture.detectChanges();
+        const titleElement = fixture.debugElement.query(By.css('h2'));
+        expect(titleElement.nativeElement.innerHTML).toBe('title');
+    });
+
+    it('should not show empty title', () => {
+        component.title = undefined;
+        fixture.detectChanges();
+        const titleElement = fixture.debugElement.query(By.css('h2'));
+        expect(titleElement.nativeElement.innerHTML).toBeFalsy();
+    });
+
     it('should show description when supplied', () => {
-        const fixture = TestBed.createComponent(EmptyStateComponent);
-
-        const testComponent = fixture.debugElement.componentInstance;
-        let descriptionElement = fixture.debugElement.query(By.css('h4'));
-
-        testComponent.title = 'TEST';
+        component.description = 'description';
         fixture.detectChanges();
-        expect(descriptionElement).toBeNull();
+        const descriptionElement = fixture.debugElement.query(By.css('h4'));
+        expect(descriptionElement.nativeElement.innerHTML).toBe('description');
+    });
 
-        testComponent.description = 'SAMPLE';
+    it('should not show empty description', () => {
+        component.description = '';
         fixture.detectChanges();
-        descriptionElement = fixture.debugElement.query(By.css('h4'));
-        expect(descriptionElement.nativeElement.innerHTML).toBe('SAMPLE');
-
-        testComponent.description = null;
-        fixture.detectChanges();
-        descriptionElement = fixture.debugElement.query(By.css('h4'));
-        expect(descriptionElement).toBeNull();
+        const descriptionElement = fixture.debugElement.query(By.css('h4'));
+        expect(descriptionElement).toBeFalsy();
     });
 
     // Action Check
     it('should show actions when supplied', () => {
-        const fixture = TestBed.createComponent(TestEmpty);
-
-        let actionElement = fixture.debugElement.query(By.css('.withActions [actions]'));
+        const actikonFixture = TestBed.createComponent(TestEmpty);
+        let actionElement = actikonFixture.debugElement.query(By.css('.withActions [actions]'));
         expect(actionElement).not.toBeNull();
 
-        actionElement = fixture.debugElement.query(By.css('.empty [actions]'));
+        actionElement = actikonFixture.debugElement.query(By.css('.empty [actions]'));
         expect(actionElement).toBeNull();
     });
 
     // Icon Check
     it('should show icon when supplied', () => {
-        const fixture = TestBed.createComponent(TestEmpty);
-
-        let actionElement = fixture.debugElement.query(By.css('.withIcon [empty-icon]'));
+        const iconFixture = TestBed.createComponent(TestEmpty);
+        let actionElement = iconFixture.debugElement.query(By.css('.withIcon [empty-icon]'));
         expect(actionElement).not.toBeNull();
 
-        actionElement = fixture.debugElement.query(By.css('.empty [empty-icon]'));
+        actionElement = iconFixture.debugElement.query(By.css('.empty [empty-icon]'));
         expect(actionElement).toBeNull();
+    });
+
+    it('should enforce class naming conventions', () => {
+        component.title = 'title';
+        component.description = 'description';
+        fixture.detectChanges();
+        const classList = [
+            '.pxb-empty-state',
+            '.pxb-empty-state-empty-icon-wrapper',
+            '.pxb-empty-state-title',
+            '.pxb-empty-state-description'
+        ];
+        for (const className of classList) {
+            count(fixture, className);
+        }
     });
 });

--- a/components/src/core/empty-state/empty-state.component.spec.ts
+++ b/components/src/core/empty-state/empty-state.component.spec.ts
@@ -1,9 +1,9 @@
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { Component } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { EmptyStateComponent } from './empty-state.component';
-import {count} from "../../utils/test-utils";
-import {EmptyStateModule} from "./empty-state.module";
+import { count } from '../../utils/test-utils';
+import { EmptyStateModule } from './empty-state.module';
 
 /** Test component that contains an MatButton. */
 @Component({
@@ -22,7 +22,6 @@ import {EmptyStateModule} from "./empty-state.module";
 class TestEmpty {}
 
 describe('Empty State Component', () => {
-
     let fixture: ComponentFixture<EmptyStateComponent>;
     let component: EmptyStateComponent;
 
@@ -99,7 +98,7 @@ describe('Empty State Component', () => {
             '.pxb-empty-state',
             '.pxb-empty-state-empty-icon-wrapper',
             '.pxb-empty-state-title',
-            '.pxb-empty-state-description'
+            '.pxb-empty-state-description',
         ];
         for (const className of classList) {
             count(fixture, className);

--- a/components/src/core/empty-state/empty-state.component.spec.ts
+++ b/components/src/core/empty-state/empty-state.component.spec.ts
@@ -38,6 +38,11 @@ describe('Empty State Component', () => {
         component = fixture.componentInstance;
     });
 
+    it('should initialize', () => {
+        fixture.detectChanges();
+        expect(component).toBeTruthy();
+    });
+
     it('should show title when supplied', () => {
         component.title = 'title';
         fixture.detectChanges();

--- a/components/src/core/empty-state/empty-state.component.spec.ts
+++ b/components/src/core/empty-state/empty-state.component.spec.ts
@@ -72,11 +72,11 @@ describe('Empty State Component', () => {
 
     // Action Check
     it('should show actions when supplied', () => {
-        const actikonFixture = TestBed.createComponent(TestEmpty);
-        let actionElement = actikonFixture.debugElement.query(By.css('.withActions [actions]'));
+        const actionFixture = TestBed.createComponent(TestEmpty);
+        let actionElement = actionFixture.debugElement.query(By.css('.withActions [actions]'));
         expect(actionElement).not.toBeNull();
 
-        actionElement = actikonFixture.debugElement.query(By.css('.empty [actions]'));
+        actionElement = actionFixture.debugElement.query(By.css('.empty [actions]'));
         expect(actionElement).toBeNull();
     });
 

--- a/components/src/core/empty-state/empty-state.component.ts
+++ b/components/src/core/empty-state/empty-state.component.ts
@@ -1,13 +1,13 @@
-import { Component, Input } from '@angular/core';
-import * as Colors from '@pxblue/colors';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, ViewEncapsulation} from '@angular/core';
 
 @Component({
     selector: 'pxb-empty-state',
     templateUrl: './empty-state.component.html',
     styleUrls: ['./empty-state.component.scss'],
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    encapsulation: ViewEncapsulation.None
 })
 export class EmptyStateComponent {
     @Input() title: string;
     @Input() description: string;
-    Colors: any = Colors;
 }

--- a/components/src/core/empty-state/empty-state.component.ts
+++ b/components/src/core/empty-state/empty-state.component.ts
@@ -1,11 +1,11 @@
-import {ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, ViewEncapsulation} from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
 
 @Component({
     selector: 'pxb-empty-state',
     templateUrl: './empty-state.component.html',
     styleUrls: ['./empty-state.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
-    encapsulation: ViewEncapsulation.None
+    encapsulation: ViewEncapsulation.None,
 })
 export class EmptyStateComponent {
     @Input() title: string;

--- a/components/src/core/hero/hero-banner.component.scss
+++ b/components/src/core/hero/hero-banner.component.scss
@@ -1,5 +1,4 @@
-@import '~@pxblue/colors/palette';
-.banner {
+.pxb-hero-banner {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -7,6 +6,5 @@
 :host ::ng-deep pxb-hero:nth-child(n + 5) {
     display: none;
 }
-.divider {
-    color: map-get($pxb-gray, 200);
+.pxb-hero-banner-divider {
 }

--- a/components/src/core/hero/hero-banner.component.spec.ts
+++ b/components/src/core/hero/hero-banner.component.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, async } from '@angular/core/testing';
+import {TestBed, async, ComponentFixture} from '@angular/core/testing';
 import { BrowserModule } from '@angular/platform-browser';
 import { HttpClientModule } from '@angular/common/http';
 import { HeroBannerComponent } from './hero-banner.component';
@@ -7,6 +7,9 @@ import { MatIconModule } from '@angular/material/icon';
 import {count} from "../../utils/test-utils";
 
 describe('HeroBannerComponent', () => {
+    let fixture: ComponentFixture<HeroBannerComponent>;
+    let component: HeroBannerComponent;
+
     beforeEach(async(() => {
         TestBed.configureTestingModule({
             declarations: [HeroBannerComponent],
@@ -14,9 +17,17 @@ describe('HeroBannerComponent', () => {
         }).compileComponents();
     }));
 
+    beforeEach(() => {
+        fixture = TestBed.createComponent(HeroBannerComponent);
+        component = fixture.componentInstance;
+    });
+
+    it('should initialize', () => {
+        fixture.detectChanges();
+        expect(component).toBeTruthy();
+    });
+
     it('should enforce class naming conventions', () => {
-        const fixture = TestBed.createComponent(HeroBannerComponent);
-        const component = fixture.componentInstance;
         component.divider = true;
         fixture.detectChanges();
         const classList = [

--- a/components/src/core/hero/hero-banner.component.spec.ts
+++ b/components/src/core/hero/hero-banner.component.spec.ts
@@ -1,10 +1,10 @@
-import {TestBed, async, ComponentFixture} from '@angular/core/testing';
+import { TestBed, async, ComponentFixture } from '@angular/core/testing';
 import { BrowserModule } from '@angular/platform-browser';
 import { HttpClientModule } from '@angular/common/http';
 import { HeroBannerComponent } from './hero-banner.component';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatIconModule } from '@angular/material/icon';
-import {count} from "../../utils/test-utils";
+import { count } from '../../utils/test-utils';
 
 describe('HeroBannerComponent', () => {
     let fixture: ComponentFixture<HeroBannerComponent>;
@@ -30,10 +30,7 @@ describe('HeroBannerComponent', () => {
     it('should enforce class naming conventions', () => {
         component.divider = true;
         fixture.detectChanges();
-        const classList = [
-            '.pxb-hero-banner',
-            '.pxb-hero-banner-divider'
-        ];
+        const classList = ['.pxb-hero-banner', '.pxb-hero-banner-divider'];
         for (const className of classList) {
             count(fixture, className);
         }

--- a/components/src/core/hero/hero-banner.component.spec.ts
+++ b/components/src/core/hero/hero-banner.component.spec.ts
@@ -1,9 +1,10 @@
 import { TestBed, async } from '@angular/core/testing';
-import { BrowserModule, By } from '@angular/platform-browser';
+import { BrowserModule } from '@angular/platform-browser';
 import { HttpClientModule } from '@angular/common/http';
 import { HeroBannerComponent } from './hero-banner.component';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatIconModule } from '@angular/material/icon';
+import {count} from "../../utils/test-utils";
 
 describe('HeroBannerComponent', () => {
     beforeEach(async(() => {
@@ -13,10 +14,17 @@ describe('HeroBannerComponent', () => {
         }).compileComponents();
     }));
 
-    it(`Div element should have class as 'wrapper'`, () => {
+    it('should enforce class naming conventions', () => {
         const fixture = TestBed.createComponent(HeroBannerComponent);
-        const heroComponent = fixture.debugElement;
-        const wrapperDiv: HTMLElement = heroComponent.query(By.css('div')).nativeElement;
-        expect(wrapperDiv.getAttribute('class')).toEqual('banner');
+        const component = fixture.componentInstance;
+        component.divider = true;
+        fixture.detectChanges();
+        const classList = [
+            '.pxb-hero-banner',
+            '.pxb-hero-banner-divider'
+        ];
+        for (const className of classList) {
+            count(fixture, className);
+        }
     });
 });

--- a/components/src/core/hero/hero-banner.component.ts
+++ b/components/src/core/hero/hero-banner.component.ts
@@ -1,12 +1,13 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
 
 @Component({
     selector: 'pxb-hero-banner',
+    changeDetection: ChangeDetectionStrategy.OnPush,
     template: `
-        <div class="banner">
+        <div class="pxb-hero-banner">
             <ng-content select="pxb-hero"></ng-content>
         </div>
-        <mat-divider class="divider" *ngIf="divider"></mat-divider>
+        <mat-divider class="pxb-hero-banner-divider" *ngIf="divider"></mat-divider>
     `,
     styleUrls: ['./hero-banner.component.scss'],
 })

--- a/components/src/core/hero/hero.component.scss
+++ b/components/src/core/hero/hero.component.scss
@@ -12,7 +12,7 @@
     padding: 16px 8px;
 
     .pxb-hero-primary-wrapper {
-        padding: 3px;
+        padding: 4px;
         $normal: 32px;
         $large: 72px;
         border-radius: 50%;

--- a/components/src/core/hero/hero.component.scss
+++ b/components/src/core/hero/hero.component.scss
@@ -1,61 +1,59 @@
-@import '~@pxblue/colors/palette';
-
 :host {
     flex: 1 1 0px;
 }
 
-.pxb-root {
+.pxb-hero {
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: flex-start;
     font-size: 1rem;
     overflow: hidden;
-    color: map-get($pxb-gray, 500);
     padding: 16px 8px;
-}
 
-.pxb-primary-wrapper {
-    padding: 3px;
-    $normal: 32px;
-    $large: 72px;
-    color: map-get($pxb-gray, 800);
-    border-radius: 50%;
-    margin-bottom: 5px;
-    text-align: center;
-}
+    .pxb-hero-primary-wrapper {
+        padding: 3px;
+        $normal: 32px;
+        $large: 72px;
+        border-radius: 50%;
+        margin-bottom: 5px;
+        text-align: center;
+    }
 
-.pxb-channel-value-wrapper {
-    display: flex;
-    color: map-get($pxb-gray, 800);
-}
-
-// Label Styles
-.pxb-label {
-    font-size: inherit;
-    line-height: 1.2;
-    letter-spacing: 0;
-    font-weight: 600;
-    width: 100%;
-    text-align: center;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    margin: 0;
-}
-
-:host ::ng-deep .pxb-primary-wrapper {
-    * {
+    .pxb-hero-channel-value-wrapper {
         display: flex;
-        align-items: center;
-        justify-content: center;
-        font-size: 100%;
+        font-size: 1.25rem;
+        &.pxb-hero-small {
+            font-size: 1rem;
+        }
     }
-    &:not(.pxb-svgIcon) * {
+
+    .pxb-hero-label {
+        font-size: inherit;
+        line-height: 1.2;
+        letter-spacing: 0;
+        font-weight: 600;
         width: 100%;
-        height: 100%;
+        text-align: center;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        margin: 0;
     }
-    &.pxb-svgIcon svg {
-        transform-origin: top left;
+
+    .pxb-hero-primary-wrapper {
+        * {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 100%;
+        }
+        &:not(.pxb-hero-svgIcon) * {
+            width: 100%;
+            height: 100%;
+        }
+        &.pxb-hero-svgIcon svg {
+            transform-origin: top left;
+        }
     }
 }

--- a/components/src/core/hero/hero.component.spec.ts
+++ b/components/src/core/hero/hero.component.spec.ts
@@ -2,15 +2,27 @@ import { TestBed, async, ComponentFixture } from '@angular/core/testing';
 import { count } from '../../utils/test-utils';
 import { HeroComponent } from './hero.component';
 import { HeroModule } from './hero.module';
+import {HeroBannerComponent} from "./hero-banner.component";
 
 describe('HeroComponent', () => {
     let fixture: ComponentFixture<HeroComponent>;
+    let component: HeroComponent;
+
     beforeEach(async(() => {
         TestBed.configureTestingModule({
             imports: [HeroModule],
         }).compileComponents();
-        fixture = TestBed.createComponent(HeroComponent);
     }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(HeroComponent);
+        component = fixture.componentInstance;
+    });
+
+    it('should initialize', () => {
+        fixture.detectChanges();
+        expect(component).toBeTruthy();
+    });
 
     it('should enforce class naming conventions', () => {
         const classList = ['.pxb-hero', '.pxb-hero-primary-wrapper', '.pxb-hero-channel-value-wrapper', '.pxb-hero-label'];

--- a/components/src/core/hero/hero.component.spec.ts
+++ b/components/src/core/hero/hero.component.spec.ts
@@ -13,7 +13,7 @@ describe('HeroComponent', () => {
     }));
 
     it('should enforce class naming conventions', () => {
-        const classList = ['.pxb-root', '.pxb-primary-wrapper', '.pxb-channel-value-wrapper', '.pxb-label'];
+        const classList = ['.pxb-hero', '.pxb-hero-primary-wrapper', '.pxb-hero-channel-value-wrapper', '.pxb-hero-label'];
         for (const className of classList) {
             count(fixture, className);
         }

--- a/components/src/core/hero/hero.component.spec.ts
+++ b/components/src/core/hero/hero.component.spec.ts
@@ -2,7 +2,6 @@ import { TestBed, async, ComponentFixture } from '@angular/core/testing';
 import { count } from '../../utils/test-utils';
 import { HeroComponent } from './hero.component';
 import { HeroModule } from './hero.module';
-import {HeroBannerComponent} from "./hero-banner.component";
 
 describe('HeroComponent', () => {
     let fixture: ComponentFixture<HeroComponent>;
@@ -25,7 +24,12 @@ describe('HeroComponent', () => {
     });
 
     it('should enforce class naming conventions', () => {
-        const classList = ['.pxb-hero', '.pxb-hero-primary-wrapper', '.pxb-hero-channel-value-wrapper', '.pxb-hero-label'];
+        const classList = [
+            '.pxb-hero',
+            '.pxb-hero-primary-wrapper',
+            '.pxb-hero-channel-value-wrapper',
+            '.pxb-hero-label',
+        ];
         for (const className of classList) {
             count(fixture, className);
         }

--- a/components/src/core/hero/hero.component.ts
+++ b/components/src/core/hero/hero.component.ts
@@ -7,36 +7,40 @@ import {
     Input,
     OnChanges,
     ViewChild,
+    ChangeDetectionStrategy,
+    ViewEncapsulation,
 } from '@angular/core';
 export type IconSize = 'small' | 'normal' | 'large' | number;
 export type FontSize = 'small' | 'normal';
 
 @Component({
     selector: 'pxb-hero',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    encapsulation: ViewEncapsulation.None,
+    styleUrls: ['./hero.component.scss'],
     template: `
-        <div class="pxb-root">
+        <div class="pxb-hero">
             <div
-                class="pxb-primary-wrapper"
+                class="pxb-hero-primary-wrapper"
                 #primaryContainer
                 [style.backgroundColor]="iconBackgroundColor"
                 [style.lineHeight.px]="iSize"
                 [style.fontSize.px]="iSize"
                 [style.width.px]="iSize"
                 [style.height.px]="iSize"
-                [class.pxb-svgIcon]="hasMatSvgIcon"
+                [class.pxb-hero-svgIcon]="hasMatSvgIcon"
             >
                 <ng-content select="[primary]"></ng-content>
             </div>
-            <span class="pxb-channel-value-wrapper" [style.fontSize.rem]="fontSize === 'small' ? '1' : '1.25'">
+            <span class="pxb-hero-channel-value-wrapper" [class.pxb-hero-small]="fontSize === 'small'">
                 <ng-content select="pxb-channel-value" *ngIf="value === undefined" ></ng-content>
                 <pxb-channel-value *ngIf="value !== undefined" [value]="value" [units]="units">
                     <ng-content select="[secondary]"></ng-content>
                 </pxb-channel-value>
             </span>
-            <h5 class="pxb-label">{{ label }}</h5>
+            <h5 class="pxb-hero-label">{{ label }}</h5>
         </div>
-    `,
-    styleUrls: ['./hero.component.scss'],
+    `
 })
 export class HeroComponent implements OnChanges, AfterViewInit, AfterContentChecked {
     @Input() color: string;

--- a/components/src/core/hero/hero.component.ts
+++ b/components/src/core/hero/hero.component.ts
@@ -33,14 +33,14 @@ export type FontSize = 'small' | 'normal';
                 <ng-content select="[primary]"></ng-content>
             </div>
             <span class="pxb-hero-channel-value-wrapper" [class.pxb-hero-small]="fontSize === 'small'">
-                <ng-content select="pxb-channel-value" *ngIf="value === undefined" ></ng-content>
+                <ng-content select="pxb-channel-value" *ngIf="value === undefined"></ng-content>
                 <pxb-channel-value *ngIf="value !== undefined" [value]="value" [units]="units">
                     <ng-content select="[secondary]"></ng-content>
                 </pxb-channel-value>
             </span>
             <h5 class="pxb-hero-label">{{ label }}</h5>
         </div>
-    `
+    `,
 })
 export class HeroComponent implements OnChanges, AfterViewInit, AfterContentChecked {
     @Input() color: string;
@@ -111,7 +111,7 @@ export class HeroComponent implements OnChanges, AfterViewInit, AfterContentChec
             this.hasMatSvgIcon = true;
             const svg = matIcon.querySelector('svg');
             if (svg) {
-                svg.style.setProperty('transform', `scale(${this.iSize/24})`);
+                svg.style.setProperty('transform', `scale(${this.iSize / 24})`);
             }
         }
     }

--- a/components/src/core/info-list-item/info-list-item.component.scss
+++ b/components/src/core/info-list-item/info-list-item.component.scss
@@ -72,7 +72,7 @@ $denseHeight: 56px;
         order: 1;
         width: 56px;
         min-width: 56px;
-        &.pxb-hide-padding {
+        &.pxb-hide-padding:empty {
             width: 0;
             min-width: unset;
         }

--- a/components/src/core/info-list-item/info-list-item.component.scss
+++ b/components/src/core/info-list-item/info-list-item.component.scss
@@ -1,5 +1,3 @@
-@import '~@pxblue/colors/palette';
-
 $statusWidth: 6px;
 $contentPaddingLeft: 16px;
 $normalHeight: 72px;
@@ -15,44 +13,44 @@ $denseHeight: 56px;
         padding: 8px 16px 8px $contentPaddingLeft;
     }
 
-    &.pxb-status .mat-list-item-content {
+    &.pxb-info-list-item-status .mat-list-item-content {
         border-left: solid $statusWidth;
         border-left-color: inherit;
         padding-left: $contentPaddingLeft - $statusWidth;
     }
 
-    &.pxb-dense .mat-list-item-content {
+    &.pxb-info-list-item-dense .mat-list-item-content {
         height: $denseHeight;
     }
 
-    &.pxb-wrap {
+    &.pxb-info-list-item-wrap {
         .mat-list-item-content {
             height: unset;
             min-height: $normalHeight;
         }
-        &.pxb-dense .mat-list-item-content {
+        &.pxb-info-list-item-dense .mat-list-item-content {
             min-height: $denseHeight;
         }
     }
 
-    .pxb-title {
+    .pxb-info-list-item-title {
         font-size: 16px; // TODO: Fix via theme
         font-weight: 600;
         line-height: 1.25;
         margin-bottom: 0;
     }
 
-    .pxb-subtitle {
+    .pxb-info-list-item-subtitle {
         font-weight: 400;
         line-height: 1.3;
     }
 
-    .pxb-title,
-    .pxb-subtitle {
+    .pxb-info-list-item-title,
+    .pxb-info-list-item-subtitle {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
-        &.pxb-wrap {
+        &.pxb-info-list-item-wrap {
             white-space: normal;
             overflow: unset;
             text-overflow: unset;
@@ -60,25 +58,25 @@ $denseHeight: 56px;
     }
 
     // Display order is below, left-to-right.
-    .pxb-icon,
-    .pxb-left-component,
+    .pxb-info-list-item-icon,
+    .pxb-info-list-item-left-component,
     .mat-list-text,
-    .pxb-spacer,
-    .pxb-right-component {
+    .pxb-info-list-item-spacer,
+    .pxb-info-list-item-right-component {
         display: flex;
     }
 
-    .pxb-icon {
+    .pxb-info-list-item-icon {
         order: 1;
         width: 56px;
         min-width: 56px;
-        &.pxb-hide-padding:empty {
+        &.pxb-info-list-item-hide-padding:empty {
             width: 0;
             min-width: unset;
         }
     }
 
-    .pxb-left-component {
+    .pxb-info-list-item-left-component {
         order: 2;
         > * {
             margin-right: 16px;
@@ -91,21 +89,21 @@ $denseHeight: 56px;
         flex-direction: column;
     }
 
-    .pxb-spacer {
+    .pxb-info-list-item-spacer {
         order: 4;
     }
 
-    .pxb-right-component {
+    .pxb-info-list-item-right-component {
         order: 5;
         margin-left: 16px;
     }
 }
 
 mat-divider {
-    &.pxb-divider {
+    &.pxb-info-list-item-divider {
         margin-top: -1px;
     }
-    &.pxb-partial-divider {
+    &.pxb-info-list-item-partial-divider {
         position: relative;
         bottom: 0;
         right: 0;

--- a/components/src/core/info-list-item/info-list-item.component.scss
+++ b/components/src/core/info-list-item/info-list-item.component.scss
@@ -80,6 +80,7 @@ $denseHeight: 56px;
         order: 2;
         > * {
             margin-right: 16px;
+            display: flex;
         }
     }
 
@@ -96,6 +97,9 @@ $denseHeight: 56px;
     .pxb-info-list-item-right-component {
         order: 5;
         margin-left: 16px;
+        .pxb-info-list-item-right-component-wrapper > * {
+            display: flex;
+        }
     }
 }
 

--- a/components/src/core/info-list-item/info-list-item.component.spec.ts
+++ b/components/src/core/info-list-item/info-list-item.component.spec.ts
@@ -1,5 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import {count} from "../../utils/test-utils";
+import { count } from '../../utils/test-utils';
 import { InfoListItemComponent } from './info-list-item.component';
 import { InfoListItemModule } from './info-list-item.module';
 import { Component } from '@angular/core';
@@ -62,7 +62,9 @@ describe('InfoListItemComponent', () => {
     it('should render a subtitle', () => {
         component.subtitle = 'Test Subtitle';
         fixture.detectChanges();
-        expect(fixture.nativeElement.querySelector('.pxb-info-list-item-subtitle').innerHTML).toContain('Test Subtitle');
+        expect(fixture.nativeElement.querySelector('.pxb-info-list-item-subtitle').innerHTML).toContain(
+            'Test Subtitle'
+        );
     });
 
     it('should render an icon', () => {
@@ -107,7 +109,7 @@ describe('InfoListItemComponent', () => {
             '.pxb-info-list-item-subtitle',
             '.pxb-info-list-item-spacer',
             '.pxb-info-list-item-right-component',
-            '.pxb-info-list-item-divider'
+            '.pxb-info-list-item-divider',
         ];
         for (const className of classList) {
             count(fixture, className);

--- a/components/src/core/info-list-item/info-list-item.component.spec.ts
+++ b/components/src/core/info-list-item/info-list-item.component.spec.ts
@@ -56,13 +56,13 @@ describe('InfoListItemComponent', () => {
     it('should render a title', () => {
         component.title = 'Test Title';
         fixture.detectChanges();
-        expect(fixture.nativeElement.querySelector('.pxb-title').innerHTML).toBe('Test Title');
+        expect(fixture.nativeElement.querySelector('.pxb-info-list-item-title').innerHTML).toBe('Test Title');
     });
 
     it('should render a subtitle', () => {
         component.subtitle = 'Test Subtitle';
         fixture.detectChanges();
-        expect(fixture.nativeElement.querySelector('.pxb-subtitle').innerHTML).toContain('Test Subtitle');
+        expect(fixture.nativeElement.querySelector('.pxb-info-list-item-subtitle').innerHTML).toContain('Test Subtitle');
     });
 
     it('should render an icon', () => {
@@ -101,13 +101,13 @@ describe('InfoListItemComponent', () => {
         fixture.detectChanges();
         const classList = [
             '.pxb-info-list-item',
-            '.pxb-icon',
-            '.pxb-left-component',
-            '.pxb-title',
-            '.pxb-subtitle',
-            '.pxb-spacer',
-            '.pxb-right-component',
-            '.pxb-divider'
+            '.pxb-info-list-item-icon',
+            '.pxb-info-list-item-left-component',
+            '.pxb-info-list-item-title',
+            '.pxb-info-list-item-subtitle',
+            '.pxb-info-list-item-spacer',
+            '.pxb-info-list-item-right-component',
+            '.pxb-info-list-item-divider'
         ];
         for (const className of classList) {
             count(fixture, className);

--- a/components/src/core/info-list-item/info-list-item.component.spec.ts
+++ b/components/src/core/info-list-item/info-list-item.component.spec.ts
@@ -110,7 +110,7 @@ describe('InfoListItemComponent', () => {
             '.pxb-info-list-item-spacer',
             '.pxb-info-list-item-right-component',
             '.pxb-info-list-item-divider',
-            '.pxb-info-list-item-right-component-wrapper'
+            '.pxb-info-list-item-right-component-wrapper',
         ];
         for (const className of classList) {
             count(fixture, className);

--- a/components/src/core/info-list-item/info-list-item.component.spec.ts
+++ b/components/src/core/info-list-item/info-list-item.component.spec.ts
@@ -56,7 +56,7 @@ describe('InfoListItemComponent', () => {
     it('should render a title', () => {
         component.title = 'Test Title';
         fixture.detectChanges();
-        expect(fixture.nativeElement.querySelector('.pxb-info-list-item-title').innerHTML).toBe('Test Title');
+        expect(fixture.nativeElement.querySelector('.pxb-info-list-item-title').innerHTML.trim()).toBe('Test Title');
     });
 
     it('should render a subtitle', () => {
@@ -110,6 +110,7 @@ describe('InfoListItemComponent', () => {
             '.pxb-info-list-item-spacer',
             '.pxb-info-list-item-right-component',
             '.pxb-info-list-item-divider',
+            '.pxb-info-list-item-right-component-wrapper'
         ];
         for (const className of classList) {
             count(fixture, className);

--- a/components/src/core/info-list-item/info-list-item.component.ts
+++ b/components/src/core/info-list-item/info-list-item.component.ts
@@ -19,8 +19,8 @@ import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@a
                 <ng-content select="[left-component]"></ng-content>
             </div>
             <div class="mat-body-1 pxb-info-list-item-title" matLine [class.pxb-info-list-item-wrap]="wrapTitle">
-                {{title}}
-            </div> 
+                {{ title }}
+            </div>
             <div class="mat-body-2 pxb-info-list-item-subtitle" matLine [class.pxb-info-list-item-wrap]="wrapSubtitle">
                 <ng-container *ngIf="subtitleIsArray">
                     <ng-container *ngFor="let sub of subtitle; let last = last">

--- a/components/src/core/info-list-item/info-list-item.component.ts
+++ b/components/src/core/info-list-item/info-list-item.component.ts
@@ -1,23 +1,25 @@
-import { Component, Input, ViewEncapsulation } from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input, ViewEncapsulation} from '@angular/core';
 
 @Component({
     selector: 'pxb-info-list-item',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    encapsulation: ViewEncapsulation.None,
     template: `
         <mat-list-item
             class="pxb-info-list-item"
-            [class.pxb-wrap]="wrapSubtitle || wrapTitle"
-            [class.pxb-dense]="dense"
-            [class.pxb-status]="statusColor"
+            [class.pxb-info-list-item-wrap]="wrapSubtitle || wrapTitle"
+            [class.pxb-info-list-item-dense]="dense"
+            [class.pxb-info-list-item-status]="statusColor"
             [style.borderLeftColor]="statusColor"
         >
-            <div mat-list-icon class="pxb-icon" [class.pxb-hide-padding]="hidePadding">
+            <div mat-list-icon class="pxb-info-list-item-icon" [class.pxb-info-list-item-hide-padding]="hidePadding">
                 <ng-content select="[icon]"></ng-content>
             </div>
-            <div class="pxb-left-component">
+            <div class="pxb-info-list-item-left-component">
                 <ng-content select="[left-component]"></ng-content>
             </div>
-            <div class="mat-body-1 pxb-title" matLine [class.pxb-wrap]="wrapTitle">{{ title }}</div>
-            <div class="mat-body-2 pxb-subtitle" matLine [class.pxb-wrap]="wrapSubtitle">
+            <div class="mat-body-1 pxb-info-list-item-title" matLine [class.pxb-info-list-item-wrap]="wrapTitle">{{ title }}</div>
+            <div class="mat-body-2 pxb-info-list-item-subtitle" matLine [class.pxb-info-list-item-wrap]="wrapSubtitle">
                 <ng-container *ngIf="subtitleIsArray">
                     <ng-container *ngFor="let sub of subtitle; let last = last">
                         {{ sub }}<ng-container *ngIf="!last">{{ subtitleSeparator }}</ng-container>
@@ -25,17 +27,16 @@ import { Component, Input, ViewEncapsulation } from '@angular/core';
                 </ng-container>
                 <ng-container *ngIf="!subtitleIsArray">{{ subtitle }}</ng-container>
             </div>
-            <pxb-spacer class="pxb-spacer"></pxb-spacer>
-            <div class="pxb-right-component">
+            <pxb-spacer class="pxb-info-list-item-spacer"></pxb-spacer>
+            <div class="pxb-info-list-item-right-component">
                 <div #right><ng-content select="[right-component]"></ng-content></div>
                 <mat-icon *ngIf="chevron && !right.innerHTML">chevron_right</mat-icon>
             </div>
         </mat-list-item>
-        <mat-divider *ngIf="divider" class="pxb-divider" [class.pxb-partial-divider]="divider === 'partial'">
+        <mat-divider *ngIf="divider" class="pxb-info-list-item-divider" [class.pxb-info-list-item-partial-divider]="divider === 'partial'">
         </mat-divider>
     `,
     styleUrls: ['./info-list-item.component.scss'],
-    encapsulation: ViewEncapsulation.None,
 })
 export class InfoListItemComponent {
     @Input() title: string;

--- a/components/src/core/info-list-item/info-list-item.component.ts
+++ b/components/src/core/info-list-item/info-list-item.component.ts
@@ -1,4 +1,4 @@
-import {ChangeDetectionStrategy, Component, Input, ViewEncapsulation} from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
 
 @Component({
     selector: 'pxb-info-list-item',
@@ -18,7 +18,9 @@ import {ChangeDetectionStrategy, Component, Input, ViewEncapsulation} from '@ang
             <div class="pxb-info-list-item-left-component">
                 <ng-content select="[left-component]"></ng-content>
             </div>
-            <div class="mat-body-1 pxb-info-list-item-title" matLine [class.pxb-info-list-item-wrap]="wrapTitle">{{ title }}</div>
+            <div class="mat-body-1 pxb-info-list-item-title" matLine [class.pxb-info-list-item-wrap]="wrapTitle">
+                {{ title }}
+            </div>
             <div class="mat-body-2 pxb-info-list-item-subtitle" matLine [class.pxb-info-list-item-wrap]="wrapSubtitle">
                 <ng-container *ngIf="subtitleIsArray">
                     <ng-container *ngFor="let sub of subtitle; let last = last">
@@ -33,7 +35,11 @@ import {ChangeDetectionStrategy, Component, Input, ViewEncapsulation} from '@ang
                 <mat-icon *ngIf="chevron && !right.innerHTML">chevron_right</mat-icon>
             </div>
         </mat-list-item>
-        <mat-divider *ngIf="divider" class="pxb-info-list-item-divider" [class.pxb-info-list-item-partial-divider]="divider === 'partial'">
+        <mat-divider
+            *ngIf="divider"
+            class="pxb-info-list-item-divider"
+            [class.pxb-info-list-item-partial-divider]="divider === 'partial'"
+        >
         </mat-divider>
     `,
     styleUrls: ['./info-list-item.component.scss'],

--- a/components/src/core/info-list-item/info-list-item.component.ts
+++ b/components/src/core/info-list-item/info-list-item.component.ts
@@ -19,8 +19,8 @@ import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@a
                 <ng-content select="[left-component]"></ng-content>
             </div>
             <div class="mat-body-1 pxb-info-list-item-title" matLine [class.pxb-info-list-item-wrap]="wrapTitle">
-                {{ title }}
-            </div>
+                {{title}}
+            </div> 
             <div class="mat-body-2 pxb-info-list-item-subtitle" matLine [class.pxb-info-list-item-wrap]="wrapSubtitle">
                 <ng-container *ngIf="subtitleIsArray">
                     <ng-container *ngFor="let sub of subtitle; let last = last">
@@ -31,7 +31,9 @@ import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@a
             </div>
             <pxb-spacer class="pxb-info-list-item-spacer"></pxb-spacer>
             <div class="pxb-info-list-item-right-component">
-                <div #right><ng-content select="[right-component]"></ng-content></div>
+                <div #right class="pxb-info-list-item-right-component-wrapper">
+                    <ng-content select="[right-component]"></ng-content>
+                </div>
                 <mat-icon *ngIf="chevron && !right.innerHTML">chevron_right</mat-icon>
             </div>
         </mat-list-item>

--- a/components/src/core/score-card/scorecard.component.scss
+++ b/components/src/core/score-card/scorecard.component.scss
@@ -39,7 +39,7 @@
         text-overflow: unset;
         overflow: unset;
         margin-right: -12px;
-       > * {
+        > * {
             cursor: pointer;
             margin-right: 12px;
             text-align: center;

--- a/components/src/core/score-card/scorecard.component.scss
+++ b/components/src/core/score-card/scorecard.component.scss
@@ -1,30 +1,26 @@
-@import '~@pxblue/colors/palette.scss';
-
-.pxb-root {
+.pxb-scorecard.mat-card {
     padding: 0;
 }
 
-// Styles applied to supplied action items.pxb-
-:host ::ng-deep .pxb-action-items * {
+// Styles applied to supplied action items.pxb-scorecard-
+:host ::ng-deep .pxb-scorecard-action-items * {
     margin-left: 12px;
     cursor: pointer;
 }
 
-.pxb-header {
+.pxb-scorecard-header {
     border-top-left-radius: inherit;
     border-top-right-radius: inherit;
     height: 100px;
     box-sizing: border-box;
     position: relative;
-    background-color: map_get($pxb-blue, 500);
-    color: map_get($pxb-white, 50);
     * {
         color: inherit;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
     }
-    .pxb-header-background {
+    .pxb-scorecard-header-background {
         position: absolute;
         width: 100%;
         height: 100%;
@@ -33,50 +29,50 @@
         background-size: cover;
         pointer-events: none;
     }
-    .pxb-header-wrapper {
+    .pxb-scorecard-header-wrapper {
         padding: 16px;
         padding-bottom: 0;
         display: flex;
         justify-content: space-between;
     }
-    .pxb-action-items-wrapper {
+    .pxb-scorecard-action-items-wrapper {
         text-overflow: unset;
         overflow: unset;
-       ::ng-deep > * {
+        margin-right: -12px;
+       > * {
             cursor: pointer;
-            height: 32px;
-            width: 32px;
+            margin-right: 12px;
             text-align: center;
         }
     }
-    .pxb-title {
+    .pxb-scorecard-title {
         font-weight: 600;
         line-height: 1.6;
         font-size: 1.125rem;
         margin-bottom: 0;
     }
-    .pxb-subtitle {
+    .pxb-scorecard-subtitle {
         font-weight: 400;
         margin: 0;
         line-height: 1.25;
     }
-    .pxb-info {
+    .pxb-scorecard-info {
         font-weight: 200;
         line-height: 2;
     }
 }
 
-.pxb-body {
+.pxb-scorecard-body {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    .pxb-badge-wrapper {
+    .pxb-scorecard-badge-wrapper {
         z-index: 1;
         margin-left: 16px;
         margin-right: 16px;
     }
 }
 
-.pxb-action-row-wrapper {
+.pxb-scorecard-action-row-wrapper {
     cursor: pointer;
 }

--- a/components/src/core/score-card/scorecard.component.scss
+++ b/components/src/core/score-card/scorecard.component.scss
@@ -42,6 +42,12 @@
     .pxb-action-items-wrapper {
         text-overflow: unset;
         overflow: unset;
+       ::ng-deep > * {
+            cursor: pointer;
+            height: 32px;
+            width: 32px;
+            text-align: center;
+        }
     }
     .pxb-title {
         font-weight: 600;

--- a/components/src/core/score-card/scorecard.component.spec.ts
+++ b/components/src/core/score-card/scorecard.component.spec.ts
@@ -45,7 +45,7 @@ describe('ScoreCardComponent', () => {
         component = fixture.componentInstance;
     });
 
-    it('should create', () => {
+    it('should initialize', () => {
         fixture.detectChanges();
         expect(component).toBeTruthy();
     });

--- a/components/src/core/score-card/scorecard.component.spec.ts
+++ b/components/src/core/score-card/scorecard.component.spec.ts
@@ -53,21 +53,21 @@ describe('ScoreCardComponent', () => {
     it('should display a header', () => {
         component.headerTitle = 'Header Title';
         fixture.detectChanges();
-        const title = fixture.nativeElement.querySelector('.pxb-title');
+        const title = fixture.nativeElement.querySelector('.pxb-scorecard-title');
         expect(title.innerHTML).toBe('Header Title');
     });
 
     it('should display a subheader', () => {
         component.headerSubtitle = 'Header Subheader';
         fixture.detectChanges();
-        const subtitle = fixture.nativeElement.querySelector('.pxb-subtitle');
+        const subtitle = fixture.nativeElement.querySelector('.pxb-scorecard-subtitle');
         expect(subtitle.innerHTML).toBe('Header Subheader');
     });
 
     it('should display a third line of text in the header', () => {
         component.headerInfo = 'Header Info';
         fixture.detectChanges();
-        const info = fixture.nativeElement.querySelector('.pxb-info');
+        const info = fixture.nativeElement.querySelector('.pxb-scorecard-info');
         expect(info.innerHTML).toBe('Header Info');
     });
 
@@ -94,18 +94,18 @@ describe('ScoreCardComponent', () => {
 
     it('should enforce class naming conventions', () => {
         const classList = [
-            '.pxb-root',
-            '.pxb-header',
-            '.pxb-header-background',
-            '.pxb-header-wrapper',
-            '.pxb-header-text',
-            '.pxb-title',
-            '.pxb-subtitle',
-            '.pxb-info',
-            '.pxb-action-items-wrapper',
-            '.pxb-body',
-            '.pxb-badge-wrapper',
-            '.pxb-action-row-wrapper',
+            '.pxb-scorecard',
+            '.pxb-scorecard-header',
+            '.pxb-scorecard-header-background',
+            '.pxb-scorecard-header-wrapper',
+            '.pxb-scorecard-header-text',
+            '.pxb-scorecard-title',
+            '.pxb-scorecard-subtitle',
+            '.pxb-scorecard-info',
+            '.pxb-scorecard-action-items-wrapper',
+            '.pxb-scorecard-body',
+            '.pxb-scorecard-badge-wrapper',
+            '.pxb-scorecard-action-row-wrapper',
         ];
         for (const className of classList) {
             count(fixture, className);

--- a/components/src/core/score-card/scorecard.component.ts
+++ b/components/src/core/score-card/scorecard.component.ts
@@ -1,4 +1,4 @@
-import {ChangeDetectionStrategy, Component, Input, ViewEncapsulation} from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
 
 @Component({
     selector: 'pxb-scorecard',

--- a/components/src/core/score-card/scorecard.component.ts
+++ b/components/src/core/score-card/scorecard.component.ts
@@ -1,31 +1,33 @@
-import { Component, Input } from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input, ViewEncapsulation} from '@angular/core';
 
 @Component({
     selector: 'pxb-scorecard',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    encapsulation: ViewEncapsulation.None,
     template: `
-        <mat-card class="pxb-root">
-            <div class="pxb-header">
-                <div class="pxb-header-background"></div>
-                <div class="pxb-header-wrapper">
-                    <div class="pxb-header-text">
-                        <mat-card-title class="pxb-title">{{ headerTitle }}</mat-card-title>
-                        <mat-card-subtitle class="pxb-subtitle">{{ headerSubtitle }}</mat-card-subtitle>
-                        <mat-card-subtitle class="pxb-info">{{ headerInfo }}</mat-card-subtitle>
+        <mat-card class="pxb-scorecard">
+            <div class="pxb-scorecard-header">
+                <div class="pxb-scorecard-header-background"></div>
+                <div class="pxb-scorecard-header-wrapper">
+                    <div class="pxb-scorecard-header-text">
+                        <mat-card-title class="pxb-scorecard-title">{{ headerTitle }}</mat-card-title>
+                        <mat-card-subtitle class="pxb-scorecard-subtitle">{{ headerSubtitle }}</mat-card-subtitle>
+                        <mat-card-subtitle class="pxb-scorecard-info">{{ headerInfo }}</mat-card-subtitle>
                     </div>
-                    <div class="pxb-action-items-wrapper">
+                    <div class="pxb-scorecard-action-items-wrapper">
                         <ng-content select="[action-items]"></ng-content>
                     </div>
                 </div>
             </div>
             <mat-card-content>
-                <div class="pxb-body">
+                <div class="pxb-scorecard-body">
                     <ng-content select="[body]"></ng-content>
-                    <div class="pxb-badge-wrapper" [style.marginTop.px]="badgeOffset || 'inherit'">
+                    <div class="pxb-scorecard-badge-wrapper" [style.marginTop.px]="badgeOffset || 'inherit'">
                         <ng-content select="[badge]"></ng-content>
                     </div>
                 </div>
                 <mat-divider *ngIf="actionRow.childNodes.length !== 0"></mat-divider>
-                <div class="pxb-action-row-wrapper" #actionRow>
+                <div class="pxb-scorecard-action-row-wrapper" #actionRow>
                     <ng-content select="[action-row]"></ng-content>
                 </div>
             </mat-card-content>

--- a/components/src/core/utility/spacer.component.spec.ts
+++ b/components/src/core/utility/spacer.component.spec.ts
@@ -13,7 +13,7 @@ describe('SpacerComponent', () => {
         component = fixture.componentInstance;
     });
 
-    it('should create', () => {
+    it('should initialize', () => {
         fixture.detectChanges();
         expect(component).toBeTruthy();
     });

--- a/components/src/core/utility/spacer.component.spec.ts
+++ b/components/src/core/utility/spacer.component.spec.ts
@@ -18,7 +18,7 @@ describe('SpacerComponent', () => {
         expect(component).toBeTruthy();
     });
 
-   it('should have a default flex value of 1', () => {
+    it('should have a default flex value of 1', () => {
         fixture.detectChanges();
         expect(component.flex).toBe(1);
         expect(component.grow).toBe('1 1 0px');

--- a/components/src/core/utility/spacer.module.ts
+++ b/components/src/core/utility/spacer.module.ts
@@ -1,4 +1,4 @@
-import {Component, HostBinding, Input, NgModule, OnChanges, OnInit} from '@angular/core';
+import { Component, HostBinding, Input, NgModule, OnChanges, OnInit } from '@angular/core';
 
 @Component({
     selector: 'pxb-spacer',

--- a/components/yarn.lock
+++ b/components/yarn.lock
@@ -983,13 +983,6 @@
     tree-kill "1.2.2"
     webpack-sources "1.4.3"
 
-"@pxblue/colors@^2.0.0":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@pxblue/colors/-/colors-2.0.1.tgz#d24dae5bc6c3b9755b52a22738aa567bfeea3b8c"
-  integrity sha512-Uceh+1Bd0acoC+KulmhxrUOkWMlOgnqXFLS02l5SHYRL3ggyjSgHBVMRp2DLt24e/OJn5tAOoNJTC9q77U297w==
-  dependencies:
-    "@pxblue/types" "^1.0.0"
-
 "@pxblue/eslint-config@^1.1.4":
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/@pxblue/eslint-config/-/eslint-config-1.1.5.tgz#7890242cb81170514aa02defd549032a834f29c3"
@@ -1011,11 +1004,6 @@
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@pxblue/prettier-config/-/prettier-config-1.0.2.tgz#fb00503df6557b66c3d91d43c9101e614c35d2ec"
   integrity sha512-/3cLBoTjZs3kV1ATPA/Sp0tsL7XmlV/b8HW/qt0jqR/uP5+cdXL2YIhMXQngLRa7PhpSkEiRIYK5sl0rKsXTUg==
-
-"@pxblue/types@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@pxblue/types/-/types-1.0.0.tgz#befa98a12ae95a407c252399c69677aa7427d97e"
-  integrity sha512-K0liTITRTZfv7n/2UmbP0g/nTelr3aaDlA5XleGqC+1hLRab20MpVaOSgLRiU8+4f0vayGtbBm63HyHgoXMROw==
 
 "@schematics/angular@8.3.26":
   version "8.3.26"
@@ -1355,11 +1343,6 @@ JSONStream@^1.3.4:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
 
-abbrev@1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
-  integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
-
 accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
@@ -1536,18 +1519,10 @@ append-transform@^1.0.0:
   dependencies:
     default-require-extensions "^2.0.0"
 
-aproba@^1.0.3, aproba@^1.1.1:
+aproba@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
   integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
-
-are-we-there-yet@~1.1.2:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz#4b35c2944f062a8bfcda66410760350fe9ddfc21"
-  integrity sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==
-  dependencies:
-    delegates "^1.0.0"
-    readable-stream "^2.0.6"
 
 arg@^4.1.0:
   version "4.1.3"
@@ -2526,11 +2501,6 @@ console-browserify@^1.1.0:
   resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.2.0.tgz#67063cef57ceb6cf4993a2ab3a55840ae8c49336"
   integrity sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==
 
-console-control-strings@^1.0.0, console-control-strings@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
-  integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
-
 constants-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
@@ -2936,11 +2906,6 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
-delegates@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
-  integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
-
 depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
@@ -2963,11 +2928,6 @@ destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
-
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-node@^2.0.4:
   version "2.0.4"
@@ -3883,20 +3843,6 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
-gauge@~2.7.3:
-  version "2.7.4"
-  resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
-  integrity sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=
-  dependencies:
-    aproba "^1.0.3"
-    console-control-strings "^1.0.0"
-    has-unicode "^2.0.0"
-    object-assign "^4.1.0"
-    signal-exit "^3.0.0"
-    string-width "^1.0.1"
-    strip-ansi "^3.0.1"
-    wide-align "^1.1.0"
-
 genfun@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/genfun/-/genfun-5.0.0.tgz#9dd9710a06900a5c4a5bf57aca5da4e52fe76537"
@@ -4113,11 +4059,6 @@ has-symbols@^1.0.0, has-symbols@^1.0.1:
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
   integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
 
-has-unicode@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
-  integrity sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=
-
 has-value@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/has-value/-/has-value-0.3.1.tgz#7b1f58bada62ca827ec0a2078025654845995e1f"
@@ -4319,7 +4260,7 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -5725,15 +5666,6 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-needle@^2.2.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.4.1.tgz#14af48732463d7475696f937626b1b993247a56a"
-  integrity sha512-x/gi6ijr4B7fwl6WYL9FwlCvRQKGlUNvnceho8wxkwXqN8jvVmmmATTmZPRRG7b/yC1eode26C2HO9jl78Du9g==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
@@ -5825,22 +5757,6 @@ node-libs-browser@^2.2.1:
     util "^0.11.0"
     vm-browserify "^1.0.1"
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 node-releases@^1.1.52, node-releases@^1.1.53:
   version "1.1.53"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.53.tgz#2d821bfa499ed7c5dffc5e2f28c88e78a08ee3f4"
@@ -5852,14 +5768,6 @@ node-sass-tilde-importer@^1.0.0:
   integrity sha512-Swcmr38Y7uB78itQeBm3mThjxBy9/Ah/ykPIaURY/L6Nec9AyRoL/jJ7ECfMR+oZeCTVQNxVMu/aHU+TLRVbdg==
   dependencies:
     find-parent-dir "^0.3.0"
-
-nopt@^4.0.1:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.3.tgz#a375cad9d02fd921278d954c2254d5aa57e15e48"
-  integrity sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==
-  dependencies:
-    abbrev "1"
-    osenv "^0.1.4"
 
 normalize-package-data@^2.0.0, normalize-package-data@^2.4.0, normalize-package-data@^2.5.0:
   version "2.5.0"
@@ -5935,7 +5843,7 @@ npm-package-arg@^6.0.0, npm-package-arg@^6.1.0:
     semver "^5.6.0"
     validate-npm-package-name "^3.0.0"
 
-npm-packlist@^1.1.12, npm-packlist@^1.1.6:
+npm-packlist@^1.1.12:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
   integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
@@ -5981,16 +5889,6 @@ npm-run-path@^2.0.0:
   integrity sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=
   dependencies:
     path-key "^2.0.0"
-
-npmlog@^4.0.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
-  integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
-  dependencies:
-    are-we-there-yet "~1.1.2"
-    console-control-strings "~1.1.0"
-    gauge "~2.7.3"
-    set-blocking "~2.0.0"
 
 num2fraction@^1.2.2:
   version "1.2.2"
@@ -6199,7 +6097,7 @@ os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
-osenv@^0.1.4, osenv@^0.1.5:
+osenv@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
   integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
@@ -6856,7 +6754,7 @@ raw-loader@3.1.0:
     loader-utils "^1.1.0"
     schema-utils "^2.0.1"
 
-rc@^1.2.7, rc@^1.2.8:
+rc@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -6917,7 +6815,7 @@ read-pkg@^5.0.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -7208,7 +7106,7 @@ rimraf@3.0.0:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^2.5.4, rimraf@^2.6.0, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3:
+rimraf@^2.5.4, rimraf@^2.6.0, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -7363,7 +7261,7 @@ sax@0.5.x:
   resolved "https://registry.yarnpkg.com/sax/-/sax-0.5.8.tgz#d472db228eb331c2506b0e8c15524adb939d12c1"
   integrity sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE=
 
-sax@^1.2.4, sax@~1.2.4:
+sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -7480,7 +7378,7 @@ serve-static@1.14.1:
     parseurl "~1.3.3"
     send "0.17.1"
 
-set-blocking@^2.0.0, set-blocking@~2.0.0:
+set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
@@ -7937,7 +7835,7 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-"string-width@^1.0.2 || 2", string-width@^2.0.0, string-width@^2.1.1:
+string-width@^2.0.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
@@ -8155,7 +8053,7 @@ tapable@^1.0.0, tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
-tar@^4.4.2, tar@^4.4.8:
+tar@^4.4.8:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
@@ -8815,13 +8713,6 @@ which@^1.2.1, which@^1.2.9, which@^1.3.1:
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
   dependencies:
     isexe "^2.0.0"
-
-wide-align@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"
-  integrity sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
-  dependencies:
-    string-width "^1.0.2 || 2"
 
 widest-line@^2.0.0:
   version "2.0.1"

--- a/demos/showcase/angular.json
+++ b/demos/showcase/angular.json
@@ -29,7 +29,7 @@
             "styles": [
               "src/styles.scss",
               "./node_modules/typeface-open-sans",
-              "./node_modules/@pxblue/themes/angular/theme.scss"
+              "./node_modules/@pxblue/angular-themes/theme.scss"
             ],
             "scripts": []
           },

--- a/demos/showcase/package.json
+++ b/demos/showcase/package.json
@@ -27,7 +27,7 @@
     "@pxblue/colors": "^1.0.13",
     "@pxblue/icons-svg": "^1.0.10",
     "@pxblue/ng-progress-icons": "^1.1.3",
-    "@pxblue/themes": "^2.0.2",
+    "@pxblue/angular-themes": "^5.0.0-beta.0",
     "core-js": "^2.5.4",
     "node-sass": "^4.13.1",
     "rxjs": "~6.3.3",

--- a/demos/showcase/src/app/app.component.scss
+++ b/demos/showcase/src/app/app.component.scss
@@ -25,7 +25,7 @@ pxb-scorecard {
 }
 
 pxb-scorecard {
-    .pxb-header-background {
+    .pxb-scorecard-header-background {
         background-image: url('../assets/topology_40.png');
     }
     .mat-list-base {
@@ -39,7 +39,7 @@ pxb-scorecard {
     }
 }
 .red-scorecard {
-    .pxb-root .pxb-header {
+    .pxb-scorecard .pxb-scorecard-header {
         background-color: map-get($pxb-red, 500);
     }
     margin-right: 16px;

--- a/demos/showcase/src/styles.scss
+++ b/demos/showcase/src/styles.scss
@@ -1,5 +1,5 @@
 /* You can add global styles to this file, and also import other style files */
-@import '~@pxblue/themes/angular/theme.scss';
+@import '~@pxblue/angular-themes/theme.scss';
 
 body {
     margin: 0;

--- a/demos/showcase/yarn.lock
+++ b/demos/showcase/yarn.lock
@@ -309,10 +309,25 @@
     tree-kill "1.2.0"
     webpack-sources "1.2.0"
 
+"@pxblue/angular-themes@^5.0.0-beta.0":
+  version "5.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@pxblue/angular-themes/-/angular-themes-5.0.0-beta.0.tgz#cb9e308fd678fc29ada63f84bd9b0286b2653a63"
+  integrity sha512-2Wj4PqmfUy9L639wB9X5EBNeq+Et4aK2NyfPGBoUw7+xaU8sYiXEofnj2jbitGY7nQ06jwysQBVjrObYp5iNhg==
+  dependencies:
+    "@pxblue/colors" "^2.0.0"
+    typeface-open-sans "^0.0.75"
+
 "@pxblue/colors@^1.0.13":
   version "1.0.13"
   resolved "https://registry.yarnpkg.com/@pxblue/colors/-/colors-1.0.13.tgz#1ed76734267f77dd4b390836f61d01439fc35132"
   integrity sha512-tneNNYclHmNNIbo6J7XXEumoJZLBXqeO2LFufWxRvIs5yeVVfaJN3zWREl1oo5KP67aDixYgEKB7LH0oeTL+lQ==
+
+"@pxblue/colors@^2.0.0":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@pxblue/colors/-/colors-2.0.1.tgz#d24dae5bc6c3b9755b52a22738aa567bfeea3b8c"
+  integrity sha512-Uceh+1Bd0acoC+KulmhxrUOkWMlOgnqXFLS02l5SHYRL3ggyjSgHBVMRp2DLt24e/OJn5tAOoNJTC9q77U297w==
+  dependencies:
+    "@pxblue/types" "^1.0.0"
 
 "@pxblue/eslint-config@^1.1.4":
   version "1.1.4"
@@ -341,13 +356,10 @@
   resolved "https://registry.yarnpkg.com/@pxblue/prettier-config/-/prettier-config-1.0.2.tgz#fb00503df6557b66c3d91d43c9101e614c35d2ec"
   integrity sha512-/3cLBoTjZs3kV1ATPA/Sp0tsL7XmlV/b8HW/qt0jqR/uP5+cdXL2YIhMXQngLRa7PhpSkEiRIYK5sl0rKsXTUg==
 
-"@pxblue/themes@^2.0.2":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@pxblue/themes/-/themes-2.1.0.tgz#cae223f37aac743697a8f3cc835b16b56dfc694e"
-  integrity sha512-ctA9HaQYmPlj8kQ8qUfO8TRWP5l7gPYSoKvD1Z2mA1KmjCTSTVS7ros/Z1VF9k5Jz4ic5KtDg0T/wJxyAJWgKA==
-  dependencies:
-    "@pxblue/colors" "^1.0.13"
-    typeface-open-sans "^0.0.54"
+"@pxblue/types@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@pxblue/types/-/types-1.0.0.tgz#befa98a12ae95a407c252399c69677aa7427d97e"
+  integrity sha512-K0liTITRTZfv7n/2UmbP0g/nTelr3aaDlA5XleGqC+1hLRab20MpVaOSgLRiU8+4f0vayGtbBm63HyHgoXMROw==
 
 "@schematics/angular@7.2.4":
   version "7.2.4"
@@ -7899,6 +7911,11 @@ typeface-open-sans@^0.0.54:
   version "0.0.54"
   resolved "https://registry.yarnpkg.com/typeface-open-sans/-/typeface-open-sans-0.0.54.tgz#20f5b5ea5c7f95d89dc1f8b2d2b1457680129cee"
   integrity sha512-w6wOd6EicZdZKf0jSU/K3EzEi3zFgvWQSN7NOpRIQI5KeMWmC5Pg/lqtBVJHB0pRChYRmLdhf4h8ROur0A3JZQ==
+
+typeface-open-sans@^0.0.75:
+  version "0.0.75"
+  resolved "https://registry.yarnpkg.com/typeface-open-sans/-/typeface-open-sans-0.0.75.tgz#20d0c330f14c0c40463c334adbedd6005389abe4"
+  integrity sha512-0lLmB7pfj113OP4T78SbpSmC4OCdFQ0vUxdSXQccsSb6qF76F92iEuC/DghFgmPswTyidk8+Hwf+PS/htiJoRQ==
 
 typescript@3.2.2:
   version "3.2.2"

--- a/demos/storybook/package.json
+++ b/demos/storybook/package.json
@@ -22,7 +22,7 @@
     "@angular/platform-browser": "~8.2.2",
     "@angular/platform-browser-dynamic": "~8.2.2",
     "@angular/router": "~8.2.2",
-    "@pxblue/angular-themes": "^4.0.0",
+    "@pxblue/angular-themes": "^5.0.0-beta.0",
     "@pxblue/colors": "^2.0.0",
     "@pxblue/icons": "^1.0.25",
     "@pxblue/storybook-themes": "^1.1.0-beta.1",

--- a/demos/storybook/package.json
+++ b/demos/storybook/package.json
@@ -27,7 +27,6 @@
     "@pxblue/icons": "^1.0.25",
     "@pxblue/storybook-themes": "^1.1.0-beta.1",
     "@pxblue/icons-svg": "^1.0.18",
-    "@pxblue/themes": "^3.0.2",
     "core-js": "^3.6.4",
     "node-sass": "^4.13.1",
     "rxjs": "~6.5.4",

--- a/demos/storybook/src/utils.ts
+++ b/demos/storybook/src/utils.ts
@@ -1,4 +1,4 @@
-import '@pxblue/themes/angular/theme.scss';
+import '@pxblue/angular-themes/theme.scss';
 import { CommonModule } from "@angular/common";
 import { Component, NgModule } from '@angular/core';
 import 'typeface-open-sans';

--- a/demos/storybook/src/welcome/welcome.component.ts
+++ b/demos/storybook/src/welcome/welcome.component.ts
@@ -1,4 +1,4 @@
-import '@pxblue/themes/angular/theme.scss';
+import '@pxblue/angular-themes/theme.scss';
 import {Component, NgModule, OnInit, OnDestroy} from '@angular/core';
 import 'typeface-open-sans';
 import {MatButtonModule} from "@angular/material/button";

--- a/demos/storybook/stories/scorecard/with-actions.stories.ts
+++ b/demos/storybook/stories/scorecard/with-actions.stories.ts
@@ -8,9 +8,8 @@ export const demoActions = ['more_vert', 'search', 'mail', 'notifications', 'lis
 export const withActions = (): any => ({
     styles: [
         `${withCustomHeaderStyles}
-        ::ng-deep pxb-scorecard .pxb-root .pxb-header {
-            background-color: ${Colors.red[500]};
-            color: ${Colors.white[50]};
+        ::ng-deep .pxb-scorecard-header {
+            background-color: ${Colors.red[500]}!important;
         }`,
     ],
     template: `

--- a/demos/storybook/stories/scorecard/with-custom-header.stories.ts
+++ b/demos/storybook/stories/scorecard/with-custom-header.stories.ts
@@ -5,7 +5,7 @@ const backgroundImage = require('../../assets/topology_40.png');
 
 export const withCustomHeaderStyles = `
     ${matListStyles}
-    ::ng-deep pxb-scorecard .pxb-header-background {
+    ::ng-deep .pxb-scorecard .pxb-scorecard-header-background {
         background-image: url(${backgroundImage});
     }`;
 

--- a/demos/storybook/stories/scorecard/with-heroes.stories.ts
+++ b/demos/storybook/stories/scorecard/with-heroes.stories.ts
@@ -6,7 +6,7 @@ import { withCustomHeaderStyles } from './with-custom-header.stories';
 export const withHeroes = (): any => ({
     styles: [
         `${withCustomHeaderStyles}
-        ::ng-deep pxb-scorecard .pxb-root .pxb-header {
+        ::ng-deep pxb-scorecard .pxb-scorecard .pxb-scorecard-header {
             background-color: ${Colors.red[500]};
             color: ${Colors.white[50]};
         }`,

--- a/demos/storybook/yarn.lock
+++ b/demos/storybook/yarn.lock
@@ -1534,14 +1534,6 @@
   resolved "https://registry.yarnpkg.com/@pxblue/storybook-themes/-/storybook-themes-1.1.0-beta.1.tgz#da671219b05e87b1baf8055a3957694321e0cf7b"
   integrity sha512-hzWrdDebjldfxXYK7qJ8XklTTgVmISNiS2sklQerCQ2M++NhpP6NjSfOiA4lZa36CInmEuDeNehXTk9qhMd5TA==
 
-"@pxblue/themes@^3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@pxblue/themes/-/themes-3.0.2.tgz#d5b83b414a83e2f96a8e0f28b034b8470ae48f69"
-  integrity sha512-csaANyUWvKBphw+2p2GbdECZLmjs6Vp0FtghprwQhLyztK5BHnhm4vJaXkYNlfGnJazNxMZwU+JQtrTEL0LSZg==
-  dependencies:
-    "@pxblue/colors" "^2.0.0"
-    typeface-open-sans "^0.0.54"
-
 "@pxblue/types@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@pxblue/types/-/types-1.0.0.tgz#befa98a12ae95a407c252399c69677aa7427d97e"
@@ -11987,11 +11979,6 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
-
-typeface-open-sans@^0.0.54:
-  version "0.0.54"
-  resolved "https://registry.yarnpkg.com/typeface-open-sans/-/typeface-open-sans-0.0.54.tgz#20f5b5ea5c7f95d89dc1f8b2d2b1457680129cee"
-  integrity sha512-w6wOd6EicZdZKf0jSU/K3EzEi3zFgvWQSN7NOpRIQI5KeMWmC5Pg/lqtBVJHB0pRChYRmLdhf4h8ROur0A3JZQ==
 
 typeface-open-sans@^0.0.75:
   version "0.0.75"

--- a/demos/storybook/yarn.lock
+++ b/demos/storybook/yarn.lock
@@ -4717,7 +4717,7 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5, debug@^3.2.6:
+debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -4750,11 +4750,6 @@ deep-equal@^1.0.1, deep-equal@^1.1.1:
     object-is "^1.0.1"
     object-keys "^1.1.1"
     regexp.prototype.flags "^1.2.0"
-
-deep-extend@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
-  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -4860,11 +4855,6 @@ detab@2.0.3, detab@^2.0.0:
   integrity sha512-Up8P0clUVwq0FnFjDclzZsy9PadzRn5FFxrr47tQQvMHqyiFYVbpH8oXDzWtF0Q7pYy3l+RPmtBl+BsFF6wH0A==
   dependencies:
     repeat-string "^1.5.4"
-
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-node@^2.0.4:
   version "2.0.4"
@@ -6675,7 +6665,7 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -6819,7 +6809,7 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@1.3.5, ini@^1.3.5, ini@~1.3.0:
+ini@1.3.5, ini@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
@@ -8444,15 +8434,6 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-needle@^2.2.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.4.1.tgz#14af48732463d7475696f937626b1b993247a56a"
-  integrity sha512-x/gi6ijr4B7fwl6WYL9FwlCvRQKGlUNvnceho8wxkwXqN8jvVmmmATTmZPRRG7b/yC1eode26C2HO9jl78Du9g==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
@@ -8559,22 +8540,6 @@ node-modules-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 node-releases@^1.1.29, node-releases@^1.1.44, node-releases@^1.1.53:
   version "1.1.53"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.53.tgz#2d821bfa499ed7c5dffc5e2f28c88e78a08ee3f4"
@@ -8609,14 +8574,6 @@ node-sass@^4.13.1:
   integrity sha1-xkZdvwirzU2zWTF/eaxopkayj/k=
   dependencies:
     abbrev "1"
-
-nopt@^4.0.1:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.3.tgz#a375cad9d02fd921278d954c2254d5aa57e15e48"
-  integrity sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==
-  dependencies:
-    abbrev "1"
-    osenv "^0.1.4"
 
 normalize-package-data@^2.0.0, normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.4.0:
   version "2.5.0"
@@ -8687,7 +8644,7 @@ npm-package-arg@^6.0.0, npm-package-arg@^6.1.0:
     semver "^5.6.0"
     validate-npm-package-name "^3.0.0"
 
-npm-packlist@^1.1.12, npm-packlist@^1.1.6:
+npm-packlist@^1.1.12:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
   integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
@@ -8734,7 +8691,7 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0, npmlog@^4.0.2, npmlog@^4.1.2:
+"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0, npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -8967,7 +8924,7 @@ os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
-osenv@0, osenv@^0.1.4, osenv@^0.1.5:
+osenv@0, osenv@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
   integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
@@ -9867,16 +9824,6 @@ raw-loader@3.1.0, raw-loader@^3.1.0:
     loader-utils "^1.1.0"
     schema-utils "^2.0.1"
 
-rc@^1.2.7:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
-  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
-  dependencies:
-    deep-extend "^0.6.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
-
 react-clientside-effect@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/react-clientside-effect/-/react-clientside-effect-1.2.2.tgz#6212fb0e07b204e714581dd51992603d1accc837"
@@ -10595,7 +10542,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3, rimraf@^2.7.1:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3, rimraf@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -10742,11 +10689,6 @@ sax@0.5.x:
   version "0.5.8"
   resolved "https://registry.yarnpkg.com/sax/-/sax-0.5.8.tgz#d472db228eb331c2506b0e8c15524adb939d12c1"
   integrity sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE=
-
-sax@^1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
-  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
 scheduler@^0.19.1:
   version "0.19.1"
@@ -11546,11 +11488,6 @@ strip-json-comments@^3.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.0.tgz#7638d31422129ecf4457440009fba03f9f9ac180"
   integrity sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==
 
-strip-json-comments@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
-
 style-loader@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-1.0.0.tgz#1d5296f9165e8e2c85d24eee0b7caf9ec8ca1f82"
@@ -11665,7 +11602,7 @@ tar@^2.0.0:
     fstream "^1.0.12"
     inherits "2"
 
-tar@^4.4.2, tar@^4.4.8:
+tar@^4.4.8:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==

--- a/demos/storybook/yarn.lock
+++ b/demos/storybook/yarn.lock
@@ -1494,10 +1494,10 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@pxblue/angular-themes@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@pxblue/angular-themes/-/angular-themes-4.0.0.tgz#8959f160520b347453953b6c306cdffa5ac72306"
-  integrity sha512-LwfxTVvHo+m2hOJTRJ+2HgV8F9fTWTdtLDaNF0MV8hBik1157kdPbvSBcIQ3je2RNj3VFb4l4RGILMgN6MaV4A==
+"@pxblue/angular-themes@^5.0.0-beta.0":
+  version "5.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@pxblue/angular-themes/-/angular-themes-5.0.0-beta.0.tgz#cb9e308fd678fc29ada63f84bd9b0286b2653a63"
+  integrity sha512-2Wj4PqmfUy9L639wB9X5EBNeq+Et4aK2NyfPGBoUw7+xaU8sYiXEofnj2jbitGY7nQ06jwysQBVjrObYp5iNhg==
   dependencies:
     "@pxblue/colors" "^2.0.0"
     typeface-open-sans "^0.0.75"


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- Hide InofListItem padding only when icon not present
- Remove @pxblue/colors dependency from @pxblue/angular-components
- Update scorecard action item styles to be 32x
- Update all components ChangeDetection strategy to be OnPush. 
- Update all components view encapsulation to be 'None'
- Prefix all components with the name `pxb-component-name-`.
- Update various unit tests
- Fix Empty State's margin issue
- Remove ChannelValue inline style Input because it conflicts with theming.
- Update to use the latest beta package of @pxblue/angular-themes

ChangeDetectionStrategy.OnPush reduces the amount of the ChangeDetection checks that'll happen within our components.  OnPush tells the UI to only redraw when an input to our component has changed.  This is appropriate because none of our components so far have any state-managing logic that would require a redraw.  The Inputs dictate what is on the screen.  This is the setting that angular material is using so I thought it'd be appropriate to use here as well.

ViewEncapsulation.None is angular material's component encapsulation setting as well.  Angular's default style encapsulation adds an invisible wrapper around each component so that styles won't be shared between components, despite duplicate class names.  Using ViewEncapsulation.None exposes our components classes to be targeted by 1. people using our components, or 2. Our global theme without the use of ::ng-deep.
::ng-deep is deprecated and might be removed in the future releases of Angular so it's best to follow suite with angular material.  

I also used angular material's class prefix style.