### PR TITLE
Feature/enforce required attr

### DIFF
--- a/components/src/core/channel-value/channel-value.component.ts
+++ b/components/src/core/channel-value/channel-value.component.ts
@@ -1,5 +1,5 @@
-import {ChangeDetectionStrategy, Component, Input, OnChanges, ViewEncapsulation} from '@angular/core';
-import {requireInput} from "../../utils/utils";
+import { ChangeDetectionStrategy, Component, Input, OnChanges, ViewEncapsulation } from '@angular/core';
+import { requireInput } from '../../utils/utils';
 
 @Component({
     selector: 'pxb-channel-value',

--- a/components/src/core/channel-value/channel-value.component.ts
+++ b/components/src/core/channel-value/channel-value.component.ts
@@ -1,4 +1,5 @@
-import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input, OnChanges, ViewEncapsulation} from '@angular/core';
+import {requireInput} from "../../utils/utils";
 
 @Component({
     selector: 'pxb-channel-value',
@@ -16,10 +17,14 @@ import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@a
     `,
     styleUrls: ['./channel-value.component.scss'],
 })
-export class ChannelValueComponent {
+export class ChannelValueComponent implements OnChanges {
     @Input() value: string | number;
     @Input() units: string;
     @Input() fontSize = 'inherit';
     @Input() prefix = false;
     @Input() color: string;
+
+    ngOnChanges(): void {
+        requireInput<ChannelValueComponent>(['value'], this);
+    }
 }

--- a/components/src/core/empty-state/empty-state.component.ts
+++ b/components/src/core/empty-state/empty-state.component.ts
@@ -1,4 +1,5 @@
-import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input, OnChanges, ViewEncapsulation} from '@angular/core';
+import {requireInput} from "../../utils/utils";
 
 @Component({
     selector: 'pxb-empty-state',
@@ -7,7 +8,11 @@ import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@a
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
 })
-export class EmptyStateComponent {
+export class EmptyStateComponent implements OnChanges {
     @Input() title: string;
     @Input() description: string;
+
+    ngOnChanges(): void {
+        requireInput<EmptyStateComponent>(['title'], this);
+    }
 }

--- a/components/src/core/empty-state/empty-state.component.ts
+++ b/components/src/core/empty-state/empty-state.component.ts
@@ -1,5 +1,5 @@
-import {ChangeDetectionStrategy, Component, Input, OnChanges, ViewEncapsulation} from '@angular/core';
-import {requireInput} from "../../utils/utils";
+import { ChangeDetectionStrategy, Component, Input, OnChanges, ViewEncapsulation } from '@angular/core';
+import { requireInput } from '../../utils/utils';
 
 @Component({
     selector: 'pxb-empty-state',

--- a/components/src/core/hero/hero.component.ts
+++ b/components/src/core/hero/hero.component.ts
@@ -10,6 +10,7 @@ import {
     ChangeDetectionStrategy,
     ViewEncapsulation,
 } from '@angular/core';
+import {requireInput} from "../../utils/utils";
 export type IconSize = 'small' | 'normal' | 'large' | number;
 export type FontSize = 'small' | 'normal';
 
@@ -60,6 +61,7 @@ export class HeroComponent implements OnChanges, AfterViewInit, AfterContentChec
     constructor(private readonly ref: ChangeDetectorRef) {}
 
     ngOnChanges(): void {
+        requireInput<HeroComponent>(['label'], this);
         this.normalizeIconSize();
     }
 

--- a/components/src/core/hero/hero.component.ts
+++ b/components/src/core/hero/hero.component.ts
@@ -10,7 +10,7 @@ import {
     ChangeDetectionStrategy,
     ViewEncapsulation,
 } from '@angular/core';
-import {requireInput} from "../../utils/utils";
+import { requireInput } from '../../utils/utils';
 export type IconSize = 'small' | 'normal' | 'large' | number;
 export type FontSize = 'small' | 'normal';
 

--- a/components/src/core/info-list-item/info-list-item.component.ts
+++ b/components/src/core/info-list-item/info-list-item.component.ts
@@ -1,4 +1,13 @@
-import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
+import {
+    AfterViewInit,
+    ChangeDetectionStrategy,
+    Component,
+    ElementRef,
+    Input,
+    ViewChild,
+    ViewEncapsulation,
+} from '@angular/core';
+import { requireContent } from '../../utils/utils';
 
 @Component({
     selector: 'pxb-info-list-item',
@@ -23,7 +32,7 @@ import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@a
             <div class="pxb-info-list-item-left-content">
                 <ng-content select="[leftContent]"></ng-content>
             </div>
-            <div class="mat-body-1 pxb-info-list-item-title" matLine [class.pxb-info-list-item-wrap]="wrapTitle">
+            <div class="mat-body-1 pxb-info-list-item-title" matLine [class.pxb-info-list-item-wrap]="wrapTitle" #title>
                 <ng-content select="[title]"></ng-content>
             </div>
             <div class="mat-body-2 pxb-info-list-item-subtitle" matLine [class.pxb-info-list-item-wrap]="wrapSubtitle">
@@ -46,7 +55,7 @@ import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@a
     `,
     styleUrls: ['./info-list-item.component.scss'],
 })
-export class InfoListItemComponent {
+export class InfoListItemComponent implements AfterViewInit {
     @Input() statusColor: string;
     @Input() chevron = false;
     @Input() dense = false;
@@ -55,6 +64,13 @@ export class InfoListItemComponent {
     @Input() wrapSubtitle = false;
     @Input() wrapTitle = false;
     @Input() divider: DividerType;
+
+    @ViewChild('title', { static: false }) title: ElementRef;
+
+    ngAfterViewInit(): void {
+        const required = { id: 'title', ref: this.title };
+        requireContent([required], this);
+    }
 }
 
 type DividerType = 'full' | 'partial' | undefined;

--- a/components/src/core/info-list-item/info-list-item.component.ts
+++ b/components/src/core/info-list-item/info-list-item.component.ts
@@ -68,7 +68,7 @@ export class InfoListItemComponent implements AfterViewInit {
     @ViewChild('title', { static: false }) title: ElementRef;
 
     ngAfterViewInit(): void {
-        const required = { id: 'title', ref: this.title };
+        const required = { selector: 'title', ref: this.title };
         requireContent([required], this);
     }
 }

--- a/components/src/core/list-item-tag/list-item-tag.component.ts
+++ b/components/src/core/list-item-tag/list-item-tag.component.ts
@@ -1,5 +1,5 @@
-import {ChangeDetectionStrategy, Component, Input, OnChanges, ViewEncapsulation} from '@angular/core';
-import { requireInput } from "../../utils/utils";
+import { ChangeDetectionStrategy, Component, Input, OnChanges, ViewEncapsulation } from '@angular/core';
+import { requireInput } from '../../utils/utils';
 
 @Component({
     selector: 'pxb-list-item-tag',

--- a/components/src/core/list-item-tag/list-item-tag.component.ts
+++ b/components/src/core/list-item-tag/list-item-tag.component.ts
@@ -1,12 +1,19 @@
-import { Component, Input } from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input, OnChanges, ViewEncapsulation} from '@angular/core';
+import { requireInput } from "../../utils/utils";
 
 @Component({
     selector: 'pxb-list-item-tag',
     templateUrl: './list-item-tag.component.html',
     styleUrls: ['./list-item-tag.component.scss'],
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    encapsulation: ViewEncapsulation.None,
 })
-export class ListItemTagComponent {
-    @Input() label: string;
+export class ListItemTagComponent implements OnChanges {
     @Input() backgroundColor: string;
     @Input() fontColor: string;
+    @Input() label: string;
+
+    ngOnChanges(): void {
+        requireInput<ListItemTagComponent>(['label'], this);
+    }
 }

--- a/components/src/core/score-card/score-card.component.ts
+++ b/components/src/core/score-card/score-card.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
-import {requireInput} from "../../utils/utils";
+import { requireInput } from '../../utils/utils';
 
 @Component({
     selector: 'pxb-score-card',

--- a/components/src/core/score-card/score-card.component.ts
+++ b/components/src/core/score-card/score-card.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
+import {requireInput} from "../../utils/utils";
 
 @Component({
     selector: 'pxb-score-card',
@@ -40,4 +41,8 @@ export class ScoreCardComponent {
     @Input() headerSubtitle: string;
     @Input() headerInfo: string;
     @Input() badgeOffset = 0;
+
+    ngOnChanges(): void {
+        requireInput<ScoreCardComponent>(['headerTitle'], this);
+    }
 }

--- a/components/src/utils/utils.ts
+++ b/components/src/utils/utils.ts
@@ -13,7 +13,7 @@ export function requireContent(contentPairs: ContentPair[], component): void {
     contentPairs.forEach((contentPair) => {
         if (!contentPair.ref.nativeElement.children || contentPair.ref.nativeElement.children.length === 0) {
             // eslint-disable-next-line no-console
-            console.warn(`PXBlue ${component.constructor.name} error: Property "${contentPair.selector}" is required.`);
+            console.warn(`PXBlue ${component.constructor.name} error: Selector "${contentPair.selector}" is required.`);
         }
     });
 }

--- a/components/src/utils/utils.ts
+++ b/components/src/utils/utils.ts
@@ -1,10 +1,24 @@
+import { ElementRef } from '@angular/core';
+
 export function requireInput<T>(inputs: Array<keyof T>, component): void {
     inputs.forEach((input) => {
-        if (component[input] === undefined
-            || component[input] === null
-            || component[input] === "") {
+        if (component[input] === undefined || component[input] === null || component[input] === '') {
             // eslint-disable-next-line no-console
-            console.warn(`Property "${input}" is required`);
+            console.warn(`PXBlue ${component.constructor.name} error: Property "${input}" is required.`);
         }
     });
 }
+
+export function requireContent(contentPairs: ContentPair[], component): void {
+    contentPairs.forEach((contentPair) => {
+        if (!contentPair.ref.nativeElement.children || contentPair.ref.nativeElement.children.length === 0) {
+            // eslint-disable-next-line no-console
+            console.warn(`PXBlue ${component.constructor.name} error: Property "${contentPair.id}" is required.`);
+        }
+    });
+}
+
+export type ContentPair = {
+    id: string;
+    ref: ElementRef;
+};

--- a/components/src/utils/utils.ts
+++ b/components/src/utils/utils.ts
@@ -1,0 +1,10 @@
+export function requireInput<T>(inputs: Array<keyof T>, component): void {
+    inputs.forEach((input) => {
+        if (component[input] === undefined
+            || component[input] === null
+            || component[input] === "") {
+            // eslint-disable-next-line no-console
+            console.warn(`Property "${input}" is required`);
+        }
+    });
+}

--- a/components/src/utils/utils.ts
+++ b/components/src/utils/utils.ts
@@ -13,12 +13,12 @@ export function requireContent(contentPairs: ContentPair[], component): void {
     contentPairs.forEach((contentPair) => {
         if (!contentPair.ref.nativeElement.children || contentPair.ref.nativeElement.children.length === 0) {
             // eslint-disable-next-line no-console
-            console.warn(`PXBlue ${component.constructor.name} error: Property "${contentPair.id}" is required.`);
+            console.warn(`PXBlue ${component.constructor.name} error: Property "${contentPair.selector}" is required.`);
         }
     });
 }
 
 export type ContentPair = {
-    id: string;
+    selector: string;
     ref: ElementRef;
 };


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- Enforce required @Inputs & ng-content projections as listed in the docs.
- If a required input or content is missing, it currently throws a warning in the console. 


Missing Input Warning: 
PXBlue EmptyStateComponent error: Property "title" is required

Missing Content Warning Example: 
PXBlue InfoListItemComponent error: Selector"title" is required.
