### PR TITLE
Feature/remove unit test warnings

### DIFF
--- a/components/src/core/empty-state/empty-state.component.spec.ts
+++ b/components/src/core/empty-state/empty-state.component.spec.ts
@@ -1,9 +1,21 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { Component } from '@angular/core';
+import {Component, Input} from '@angular/core';
 import { By } from '@angular/platform-browser';
-import { EmptyStateComponent } from './empty-state.component';
-import { count, disableWarnings } from '../../utils/test-utils';
+import { count } from '../../utils/test-utils';
 import { EmptyStateModule } from './empty-state.module';
+
+@Component({
+    selector: 'empty-state-basic-usage-test',
+    template: `
+        <pxb-empty-state [title]="title" [description]="description">
+            <span emptyIcon></span>
+        </pxb-empty-state>
+    `,
+})
+class EmptyStateBasicUsageComponent {
+    @Input() title: string = 'Placeholder Title';
+    @Input() description: string;
+}
 
 /** Test component that contains an MatButton. */
 @Component({
@@ -19,23 +31,23 @@ import { EmptyStateModule } from './empty-state.module';
         </pxb-empty-state>
     `,
 })
-class TestEmpty {}
+class TestEmpty {
+}
 
 describe('Empty State Component', () => {
-    let fixture: ComponentFixture<EmptyStateComponent>;
-    let component: EmptyStateComponent;
+    let fixture: ComponentFixture<EmptyStateBasicUsageComponent>;
+    let component: EmptyStateBasicUsageComponent;
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({
             imports: [EmptyStateModule],
-            declarations: [TestEmpty],
+            declarations: [EmptyStateBasicUsageComponent,  TestEmpty],
         }).compileComponents();
     }));
 
     beforeEach(() => {
-        fixture = TestBed.createComponent(EmptyStateComponent);
+        fixture = TestBed.createComponent(EmptyStateBasicUsageComponent);
         component = fixture.componentInstance;
-        disableWarnings();
     });
 
     it('should initialize', () => {
@@ -50,8 +62,16 @@ describe('Empty State Component', () => {
         expect(titleElement.nativeElement.innerHTML).toBe('title');
     });
 
+    it('should throw a warning when the title is not supplied', () => {
+        component.title = undefined;
+        const warnSpy = spyOn(console, 'warn').and.stub();
+        fixture.detectChanges();
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
     it('should not show empty title', () => {
         component.title = undefined;
+        spyOn(console, 'warn').and.stub();
         fixture.detectChanges();
         const titleElement = fixture.debugElement.query(By.css('h2'));
         expect(titleElement.nativeElement.innerHTML).toBeFalsy();

--- a/components/src/core/empty-state/empty-state.component.spec.ts
+++ b/components/src/core/empty-state/empty-state.component.spec.ts
@@ -13,7 +13,7 @@ import { EmptyStateModule } from './empty-state.module';
     `,
 })
 class EmptyStateBasicUsageComponent {
-    @Input() title: string = 'Placeholder Title';
+    @Input() title = 'Placeholder Title';
     @Input() description: string;
 }
 

--- a/components/src/core/empty-state/empty-state.component.spec.ts
+++ b/components/src/core/empty-state/empty-state.component.spec.ts
@@ -2,7 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { Component } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { EmptyStateComponent } from './empty-state.component';
-import { count } from '../../utils/test-utils';
+import { count, disableWarnings } from '../../utils/test-utils';
 import { EmptyStateModule } from './empty-state.module';
 
 /** Test component that contains an MatButton. */
@@ -35,6 +35,7 @@ describe('Empty State Component', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(EmptyStateComponent);
         component = fixture.componentInstance;
+        disableWarnings();
     });
 
     it('should initialize', () => {

--- a/components/src/core/empty-state/empty-state.component.ts
+++ b/components/src/core/empty-state/empty-state.component.ts
@@ -6,9 +6,9 @@ import {
     Input,
     OnChanges,
     ViewChild,
-    ViewEncapsulation
+    ViewEncapsulation,
 } from '@angular/core';
-import {requireContent, requireInput} from '../../utils/utils';
+import { requireContent, requireInput } from '../../utils/utils';
 
 @Component({
     selector: 'pxb-empty-state',

--- a/components/src/core/info-list-item/info-list-item.component.spec.ts
+++ b/components/src/core/info-list-item/info-list-item.component.spec.ts
@@ -1,5 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { count } from '../../utils/test-utils';
+import { count, disableWarnings } from '../../utils/test-utils';
 import { InfoListItemComponent } from './info-list-item.component';
 import { InfoListItemModule } from './info-list-item.module';
 import { Component } from '@angular/core';
@@ -60,6 +60,7 @@ describe('InfoListItemComponent', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(InfoListItemComponent);
         component = fixture.componentInstance;
+        disableWarnings();
     });
 
     it('should initialize', () => {

--- a/components/src/core/info-list-item/info-list-item.component.spec.ts
+++ b/components/src/core/info-list-item/info-list-item.component.spec.ts
@@ -1,20 +1,37 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { count, disableWarnings } from '../../utils/test-utils';
-import { InfoListItemComponent } from './info-list-item.component';
+import { count } from '../../utils/test-utils';
 import { InfoListItemModule } from './info-list-item.module';
-import { Component } from '@angular/core';
+import {Component, Input} from '@angular/core';
 import { By } from '@angular/platform-browser';
 
 @Component({
     template: `
-        <pxb-info-list-item>
+        <pxb-info-list-item
+            [statusColor]="statusColor"
+            [chevron]="chevron"
+            [dense]="dense"
+            [avatar]="avatar"
+            [hidePadding]="hidePadding"
+            [wrapSubtitle]="wrapSubtitle"
+            [wrapTitle]="wrapTitle"
+            [divider]="divider"
+            >
             <div title>Test Title</div>
             <div subtitle>Test Subtitle</div>
             <mat-icon icon>mail</mat-icon>
         </pxb-info-list-item>
     `,
 })
-class TestBasicUsage {}
+class TestBasicUsage {
+    @Input() statusColor;
+    @Input() chevron;
+    @Input() dense;
+    @Input() avatar;
+    @Input() hidePadding;
+    @Input() wrapSubtitle;
+    @Input() wrapTitle;
+    @Input() divider: any;
+}
 
 @Component({
     template: `
@@ -25,6 +42,14 @@ class TestBasicUsage {}
     `,
 })
 class TestIconComponent {}
+
+@Component({
+    template: `
+        <pxb-info-list-item>
+        </pxb-info-list-item>
+    `,
+})
+class TestMissingTitle {}
 
 @Component({
     template: `
@@ -47,20 +72,19 @@ class TestLeftContent {}
 class TestRightContent {}
 
 describe('InfoListItemComponent', () => {
-    let component: InfoListItemComponent;
-    let fixture: ComponentFixture<InfoListItemComponent>;
+    let component: TestBasicUsage;
+    let fixture: ComponentFixture<TestBasicUsage>;
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({
-            declarations: [TestBasicUsage, TestIconComponent, TestLeftContent, TestRightContent],
+            declarations: [TestBasicUsage, TestMissingTitle, TestIconComponent, TestLeftContent, TestRightContent],
             imports: [InfoListItemModule],
         }).compileComponents();
     }));
 
     beforeEach(() => {
-        fixture = TestBed.createComponent(InfoListItemComponent);
+        fixture = TestBed.createComponent(TestBasicUsage);
         component = fixture.componentInstance;
-        disableWarnings();
     });
 
     it('should initialize', () => {
@@ -69,19 +93,24 @@ describe('InfoListItemComponent', () => {
     });
 
     it('should render a title', () => {
-        const customFixture = TestBed.createComponent(TestBasicUsage);
-        customFixture.detectChanges();
-        expect(customFixture.nativeElement.querySelector('.pxb-info-list-item-title-wrapper').innerHTML).toContain(
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector('.pxb-info-list-item-title-wrapper').innerHTML).toContain(
             'Test Title'
         );
     });
 
     it('should render a subtitle', () => {
-        const customFixture = TestBed.createComponent(TestBasicUsage);
-        customFixture.detectChanges();
-        expect(customFixture.nativeElement.querySelector('.pxb-info-list-item-subtitle-wrapper').innerHTML).toContain(
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector('.pxb-info-list-item-subtitle-wrapper').innerHTML).toContain(
             'Test Subtitle'
         );
+    });
+
+    it('should throw a warning if a title is not provided', () => {
+        const customFixture = TestBed.createComponent(TestMissingTitle);
+        const warnSpy = spyOn(console, 'warn').and.stub();
+        customFixture.detectChanges();
+        expect(warnSpy).toHaveBeenCalledTimes(1);
     });
 
     it('should render an icon', () => {

--- a/components/src/utils/test-utils.ts
+++ b/components/src/utils/test-utils.ts
@@ -8,3 +8,7 @@ export const count = (fixture: ComponentFixture<any>, selector: string, expected
         `Expected ${expected} instances of '${selector}', but found ${instances.length}`
     );
 };
+
+export const disableWarnings = (): void => {
+    spyOn(console, 'warn').and.stub();
+};

--- a/components/src/utils/test-utils.ts
+++ b/components/src/utils/test-utils.ts
@@ -8,7 +8,3 @@ export const count = (fixture: ComponentFixture<any>, selector: string, expected
         `Expected ${expected} instances of '${selector}', but found ${instances.length}`
     );
 };
-
-export const disableWarnings = (): void => {
-    spyOn(console, 'warn').and.stub();
-};


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- EmptyState and InfoListItem require certain ng-content to be projected into it.   When this content is not present, it throws a warning in the console. 
- Create wrapping test-components used to test content projection.  
- Add unit tests for checking to see if a warning is thrown when missing required attribute. 
