### PR TITLE
Update vertical bar usage in docs

### DIFF
--- a/docs/Drawer.md
+++ b/docs/Drawer.md
@@ -23,10 +23,10 @@ Parent element (`<pxb-drawer>`) attributes:
 
 <div style="overflow: auto;">
 
-| @Input               | Description                               | Type                                       | Required | Default   |
-| -------------------- | ----------------------------------------- | ------------------------------------------ | -------- | ----------|
-| variant              | Sets the drawer variant                   | `'permanent' | 'persistent' | 'temporary'` | no       |           |
-| variantDrawerHandler | Handles drawerOpen for persistent variant | `boolean`                                  | no       |           |
+| @Input               | Description                               | Type                                                    | Required | Default   |
+| -------------------- | ----------------------------------------- | ------------------------------------------------------- | -------- | ----------|
+| variant              | Sets the drawer variant                   | `'permanent'` \| `'persistent'` \| `'temporary'`        | no       |           |
+| variantDrawerHandler | Handles drawerOpen for persistent variant | `boolean`                                               | no       |           |
 
 | @Output          | Description                              | Type           | Required | Default |
 | ---------------- | ---------------------------------------- | -------------- | -------- | ------- |
@@ -77,10 +77,10 @@ Parent element (`<pxb-drawer-layout>`) attributes:
 
 <div style="overflow: auto;">
 
-| @Input     | Description                          | Type                                       | Required | Default     |
-| ---------- | ------------------------------------ | ------------------------------------------ | -------- | ----------- |
-| drawerOpen | Whether the drawer is open or closed | `boolean`                                  | no       |             |
-| variant    | Sets the drawer variant              | `'permanent' | 'persistent' | 'temporary'` | no       |             |
+| @Input     | Description                          | Type                                                    | Required | Default     |
+| ---------- | ------------------------------------ | ------------------------------------------------------- | -------- | ----------- |
+| drawerOpen | Whether the drawer is open or closed | `boolean`                                               | no       |             |
+| variant    | Sets the drawer variant              | `'permanent'` \| `'persistent'` \| `'temporary'`        | no       |             |
 
 | @Output       | Description                              | Type           | Required | Default |
 | ------------- | ---------------------------------------- | -------------- | -------- | ------- |
@@ -287,22 +287,22 @@ Parent element (`<pxb-drawer-nav-item>`) attributes:
 
 <div style="overflow: auto;">
 
-| @input                   | Description                                | Type                 | Required | Default |
-| ------------------------ | ------------------------------------------ | -------------------- | -------- | ------- |
-| activeItemBackgroundShape| Sets the active item background shape      | `'round' | 'square'` | no       | 'round' |
-| chevron                  | Sets whether to show chevron               | `boolean`            | no       | false   |
-| collapseIcon             | Icon used to collapse nested pxb-nav-items | `string`             | no       |         |
-| divider                  | Sets whether to show divider               | `boolean`            | no       | true    |
-| expandIcon               | Icon used to expand nested pxb-nav-items   | `string`             | no       |         |
-| hidePadding              | Sets whether to show/hide padding          | `boolean`            | no       |         |
-| itemID                   | ID used to track 'selected' item           | `string`             | no       |         |
-| ripple                   | Sets whether to show/hide ripple           | `boolean`            | no       | true    |
-| selected                 | Sets whether an item is selected           | `boolean`            | no       |         |
-| showNestedNavItems       | Sets whether to show/hide nested items     | `boolean`            | no       | false   |
-| statusColor              | Status stripe color                        | `string`             | no       |         |
-| subtitle                 | Text to display as a subtitle              | `string`             | no       |         |
-| title                    | Text to display as a title                 | `string`             | no       |         |
-| useCustomIconAnimation   | Sets whether to show/hide icon animation   | `boolean`            | no       | true    |
+| @input                   | Description                                | Type                             | Required | Default |
+| ------------------------ | ------------------------------------------ | -------------------------------- | -------- | ------- |
+| activeItemBackgroundShape| Sets the active item background shape      | `'round'` \| `'square'`          | no       | 'round' |
+| chevron                  | Sets whether to show chevron               | `boolean`                        | no       | false   |
+| collapseIcon             | Icon used to collapse nested pxb-nav-items | `string`                         | no       |         |
+| divider                  | Sets whether to show divider               | `boolean`                        | no       | true    |
+| expandIcon               | Icon used to expand nested pxb-nav-items   | `string`                         | no       |         |
+| hidePadding              | Sets whether to show/hide padding          | `boolean`                        | no       |         |
+| itemID                   | ID used to track 'selected' item           | `string`                         | no       |         |
+| ripple                   | Sets whether to show/hide ripple           | `boolean`                        | no       | true    |
+| selected                 | Sets whether an item is selected           | `boolean`                        | no       |         |
+| showNestedNavItems       | Sets whether to show/hide nested items     | `boolean`                        | no       | false   |
+| statusColor              | Status stripe color                        | `string`                         | no       |         |
+| subtitle                 | Text to display as a subtitle              | `string`                         | no       |         |
+| title                    | Text to display as a title                 | `string`                         | no       |         |
+| useCustomIconAnimation   | Sets whether to show/hide icon animation   | `boolean`                        | no       | true    |
 
 </div>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,7 @@
 We currently have the following components available for Angular applications:
 
 - [Channel Value](https://github.com/pxblue/angular-component-library/blob/dev/docs/ChannelValue.md)
+- [Drawer](https://github.com/pxblue/angular-component-library/blob/dev/docs/Drawer.md)
 - [Empty State](https://github.com/pxblue/angular-component-library/blob/dev/docs/EmptyState.md)
 - [Hero & Hero Banner](https://github.com/pxblue/angular-component-library/blob/dev/docs/Hero.md)
 - [Info List Item](https://github.com/pxblue/angular-component-library/blob/dev/docs/InfoListItem.md)


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
For PXBLUE-1355.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- Update to consistent usage of vertical bar in readme tables
- Add missing link for drawer docs
