### PR TITLE
Bug/ng 9 nested nav items

### DIFF
--- a/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.ts
+++ b/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.ts
@@ -123,7 +123,7 @@ export class DrawerNavItemComponent extends StateListener implements Omit<Drawer
         }
 
         // If ContentChildren is self-inclusive (ng version < 9), filter self out using service-generated NavItem ID.
-        this.nestedNavItems = this.nestedNavItems.filter((item: DrawerNavItemComponent) =>  item.id !== this.id);
+        this.nestedNavItems = this.nestedNavItems.filter((item: DrawerNavItemComponent) => item.id !== this.id);
         if (!this.nestedNavItems) {
             return;
         }

--- a/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.ts
+++ b/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.ts
@@ -101,23 +101,35 @@ export class DrawerNavItemComponent extends StateListener implements Omit<Drawer
 
     @Output() select: EventEmitter<string> = new EventEmitter<string>();
 
-    @ContentChildren(DrawerNavItemComponent) nestedNavItems;
+    @ContentChildren(DrawerNavItemComponent, { descendants: false }) nestedNavItems;
     @ViewChild('expandIcon', { static: false }) expandIconEl: ElementRef;
     @ViewChild('collapseIcon', { static: false }) collapseIconEl: ElementRef;
 
     isEmpty = (el): boolean => isEmptyView(el);
     isNestedItem: boolean;
     drawerOpen: boolean;
-    hasChildren: boolean;
+    hasChildren = false;
     depth: number;
+    id: number;
 
     constructor(drawerService: DrawerService, private readonly changeDetectorRef: ChangeDetectorRef) {
         super(drawerService, changeDetectorRef);
+        this.id = drawerService.createNavItemID();
     }
 
     ngAfterContentInit(): void {
-        this.hasChildren = this.nestedNavItems.length > 1; // ContentChildren is self-inclusive; the first result is this DrawerNavItem, not the nested DrawerNavItems.
-        for (const nestedItem of this.nestedNavItems._results.slice(1)) {
+        if (!this.nestedNavItems) {
+            return;
+        }
+
+        // If ContentChildren is self-inclusive (ng version < 9), filter self out using service-generated NavItem ID.
+        this.nestedNavItems = this.nestedNavItems.filter((item: DrawerNavItemComponent) =>  item.id !== this.id);
+        if (!this.nestedNavItems) {
+            return;
+        }
+
+        this.hasChildren = this.nestedNavItems.length >= 1;
+        for (const nestedItem of this.nestedNavItems) {
             nestedItem.setNestedDrawerDefaults();
         }
     }
@@ -135,8 +147,10 @@ export class DrawerNavItemComponent extends StateListener implements Omit<Drawer
 
     incrementDepth(parentDepth: number): void {
         this.depth = parentDepth + 1;
-        for (const nestedItem of this.nestedNavItems._results.slice(1)) {
-            nestedItem.incrementDepth(this.depth);
+        if (this.nestedNavItems._results) {
+            for (const nestedItem of this.nestedNavItems._results) {
+                nestedItem.incrementDepth(this.depth);
+            }
         }
     }
 

--- a/components/src/core/drawer/drawer-layout/drawer-layout.component.ts
+++ b/components/src/core/drawer/drawer-layout/drawer-layout.component.ts
@@ -47,6 +47,9 @@ export class DrawerLayoutComponent extends StateListener {
             this.transition = true;
         }, 400);
         this.drawerService.setDrawerVariant(this.variant);
+        if (this.variant === 'permanent') {
+            this.drawerService.setDrawerOpen(true);
+        }
         this.changeDetectorRef.detectChanges();
     }
 

--- a/components/src/core/drawer/service/drawer.service.ts
+++ b/components/src/core/drawer/service/drawer.service.ts
@@ -8,6 +8,7 @@ import { DrawerLayoutVariantType } from '../..';
 export class DrawerService {
     private drawerOpen: boolean;
     private variant: DrawerLayoutVariantType;
+    private navItemCount = 0;
     drawerOpenObs = new Subject<boolean>();
     drawerSelectObs = new Subject<boolean>();
 
@@ -38,5 +39,9 @@ export class DrawerService {
 
     drawerSelectionChanges(): Observable<boolean> {
         return this.drawerSelectObs;
+    }
+
+    createNavItemID(): number {
+        return ++this.navItemCount;
     }
 }

--- a/demos/storybook/stories/drawer/with-nested-nav-items.stories.ts
+++ b/demos/storybook/stories/drawer/with-nested-nav-items.stories.ts
@@ -12,6 +12,24 @@ export const nestedNavGroup: DrawerNavItem[] = [
                 title: 'History',
                 onSelect: action('Selected: History'),
             },
+            {
+                title: 'Permissions',
+                onSelect: action('Selected: Permissions'),
+                items: [
+                    {
+                        title: 'View',
+                        onSelect: action('Selected: View'),
+                    },
+                    {
+                        title: 'Request',
+                        onSelect: action('Selected: Request'),
+                    },
+                ],
+            },
+            {
+                title: 'Settings',
+                onSelect: action('Selected: Settings'),
+            },
         ],
     },
     {

--- a/demos/storybook/stories/drawer/with-nested-nav-items.stories.ts
+++ b/demos/storybook/stories/drawer/with-nested-nav-items.stories.ts
@@ -12,24 +12,6 @@ export const nestedNavGroup: DrawerNavItem[] = [
                 title: 'History',
                 onSelect: action('Selected: History'),
             },
-            {
-                title: 'Permissions',
-                onSelect: action('Selected: Permissions'),
-                items: [
-                    {
-                        title: 'View',
-                        onSelect: action('Selected: View'),
-                    },
-                    {
-                        title: 'Request',
-                        onSelect: action('Selected: Request'),
-                    },
-                ],
-            },
-            {
-                title: 'Settings',
-                onSelect: action('Selected: Settings'),
-            },
         ],
     },
     {


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #88 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- Changes the way that DrawerNavItem checks to see if it has any children (nested nav items).

Summary of the problem:
DrawerNavItems use ContentChildren to search its template for nested nav items.  In Ng version <8, ContentChildren is self-inclusive, meaning if a DrawerNavItem looks for all instances of DrawerNavItems within its template, it includes itself in the search results.  This has changed in ng v9 to not consider the parent component as part of its ContentChildren. 

Instead of using size of ContentChildren(DrawerNavItems) to determine if a DrawerNavItem has nested nav items, I have added an auto-generated ID to each DrawerNavItem.  We still use ContentChildren to search for any instances of DrawerNavItems, but now we can use the `id` to filter out the parent component from the ContentChildren search results.   This solution will work regardless of whether ContentChildren searching is self-inclusive or not. 

- If the variant changes to `permanent`, set drawer open state to true. 

