### PR TITLE
Fix info list item padding when no icon/left-content is provided in ng9

### DIFF
--- a/components/src/core/info-list-item/info-list-item.component.scss
+++ b/components/src/core/info-list-item/info-list-item.component.scss
@@ -14,6 +14,11 @@ $denseHeight: 52px;
         height: $normalHeight;
         padding: 8px 16px 8px $contentPaddingLeft;
         width: 100%;
+
+        // Needed for ng v9
+        .mat-list-text {
+            padding-left: 0;
+        }
     }
 
     &.pxb-info-list-item-status .mat-list-item-content {
@@ -77,6 +82,7 @@ $denseHeight: 52px;
         height: auto; /* Used to override height applied when wrapped in a mat-list. */
         min-width: 56px;
         &.pxb-info-list-item-hide-padding:empty {
+            padding: 0;
             width: 0;
             min-width: unset;
         }


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- Fixes left-padding on InfoListItem in angular v9.
- Removes padding from empty icon-wrapper div.

Angular material v9 adds 16px left-padding to mat-list-text.  This fix adds a rule to remove it.
![image](https://user-images.githubusercontent.com/6538289/85407045-acc6f880-b530-11ea-981a-2e8a64da0f06.png)

