### PR TITLE
Graceful unsubscribe, useful for unit tests

### DIFF
--- a/components/src/core/drawer/state-listener.component.ts
+++ b/components/src/core/drawer/state-listener.component.ts
@@ -14,7 +14,9 @@ export class StateListener implements OnInit, OnDestroy {
     }
 
     public ngOnDestroy(): void {
-        this.drawerOpenListener.unsubscribe();
+        if (this.drawerOpenListener) {
+            this.drawerOpenListener.unsubscribe();
+        }
     }
 
     listenForDrawerChanges(): void {


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- Allow the base Drawer component to gracefully unsubscribe instead of throwing this error when the DrawerService is not provided in unit tests: 
![image](https://user-images.githubusercontent.com/6538289/85410680-632cdc80-b535-11ea-9619-f743001b5676.png)



