### PR TITLE
Bug/hero styles

### DIFF
--- a/components/src/core/hero/hero.component.scss
+++ b/components/src/core/hero/hero.component.scss
@@ -9,7 +9,6 @@
     padding: 16px 8px;
 
     .pxb-hero-primary-wrapper {
-        padding: 4px;
         $normal: 32px;
         $large: 72px;
         border-radius: 50%;
@@ -45,6 +44,10 @@
         &:not(.pxb-hero-svgIcon) > * {
             width: 100%;
             height: 100%;
+            svg {
+                width: 100%;
+                height: 100%;
+            }
         }
         &.pxb-hero-svgIcon svg {
             transform-origin: top left;

--- a/components/src/core/hero/hero.component.scss
+++ b/components/src/core/hero/hero.component.scss
@@ -42,7 +42,7 @@
             justify-content: center;
             font-size: 100%;
         }
-        &:not(.pxb-hero-svgIcon) * {
+        &:not(.pxb-hero-svgIcon) > * {
             width: 100%;
             height: 100%;
         }

--- a/demos/storybook/package.json
+++ b/demos/storybook/package.json
@@ -30,6 +30,7 @@
         "@pxblue/icons": "^1.0.25",
         "@pxblue/icons-svg": "^1.0.18",
         "@pxblue/storybook-themes": "^1.1.0",
+        "@pxblue/ng-progress-icons": "^1.1.4",
         "core-js": "^3.6.4",
         "node-sass": "^4.14.1",
         "rxjs": "~6.5.4",

--- a/demos/storybook/stories/hero/different-image-types.component.ts
+++ b/demos/storybook/stories/hero/different-image-types.component.ts
@@ -4,6 +4,7 @@ import { BrowserModule, DomSanitizer } from '@angular/platform-browser';
 import { HeroModule } from '@pxblue/angular-components';
 import * as Colors from '@pxblue/colors';
 import { HttpClientModule } from '@angular/common/http';
+import {NgProgressIconsModule} from "@pxblue/ng-progress-icons";
 const iconSet = require('@pxblue/icons-svg/icons.svg');
 const Trex = require('../../assets/trex.png');
 
@@ -23,6 +24,9 @@ const Trex = require('../../assets/trex.png');
             <pxb-hero label="PNG" value="36px" [iconBackgroundColor]="colors.white[50]">
                 <img pxb-primary [src]="trex" alt="A T-Rex as the avatar image" />
             </pxb-hero>
+            <pxb-hero label="progress icon" value="36px" [iconBackgroundColor]="colors.white[50]">
+                <battery-progress pxb-primary size="36" [color]="colors.red[500]" percent="15"></battery-progress>
+            </pxb-hero>
         </pxb-hero-banner>
 
         <pxb-hero-banner>
@@ -38,6 +42,9 @@ const Trex = require('../../assets/trex.png');
             <pxb-hero label="PNG" units="px" value="48" iconSize="48" [iconBackgroundColor]="colors.white[50]">
                 <img pxb-primary [src]="trex" alt="A T-Rex as the avatar image" />
             </pxb-hero>
+            <pxb-hero label="progress icon" value="48px" iconSize="48" [iconBackgroundColor]="colors.white[50]">
+                <battery-progress pxb-primary size="48" [color]="colors.yellow[500]" percent="50"></battery-progress>
+            </pxb-hero>
         </pxb-hero-banner>
 
         <pxb-hero-banner>
@@ -52,6 +59,9 @@ const Trex = require('../../assets/trex.png');
             </pxb-hero>
             <pxb-hero label="PNG" value="72px" iconSize="72" [iconBackgroundColor]="colors.white[50]">
                 <img pxb-primary [src]="trex" alt="A T-Rex as the avatar image" />
+            </pxb-hero>
+            <pxb-hero label="progress icon" value="72px" iconSize="72" [iconBackgroundColor]="colors.white[50]">
+                <battery-progress pxb-primary size="72" [color]="colors.green[500]" percent="92"></battery-progress>
             </pxb-hero>
         </pxb-hero-banner>
     `,
@@ -69,7 +79,7 @@ export class DifferentImageTypesComponent {
 
 @NgModule({
     declarations: [DifferentImageTypesComponent],
-    imports: [MatIconModule, BrowserModule, HeroModule, HttpClientModule],
+    imports: [MatIconModule, BrowserModule, HeroModule, HttpClientModule, NgProgressIconsModule],
     exports: [DifferentImageTypesComponent],
 })
 export class DifferentImageTypesModule {}

--- a/demos/storybook/stories/hero/different-image-types.component.ts
+++ b/demos/storybook/stories/hero/different-image-types.component.ts
@@ -25,7 +25,7 @@ const Trex = require('../../assets/trex.png');
                 <img pxb-primary [src]="trex" alt="A T-Rex as the avatar image" />
             </pxb-hero>
             <pxb-hero label="progress icon" value="36px" [iconBackgroundColor]="colors.white[50]">
-                <battery-progress pxb-primary size="36" [color]="colors.red[500]" percent="15"></battery-progress>
+                <battery-progress pxb-primary [color]="colors.red[500]" percent="15"></battery-progress>
             </pxb-hero>
         </pxb-hero-banner>
 
@@ -43,7 +43,7 @@ const Trex = require('../../assets/trex.png');
                 <img pxb-primary [src]="trex" alt="A T-Rex as the avatar image" />
             </pxb-hero>
             <pxb-hero label="progress icon" value="48px" iconSize="48" [iconBackgroundColor]="colors.white[50]">
-                <battery-progress pxb-primary size="48" [color]="colors.yellow[500]" percent="50"></battery-progress>
+                <battery-progress pxb-primary [color]="colors.yellow[500]" percent="50"></battery-progress>
             </pxb-hero>
         </pxb-hero-banner>
 
@@ -61,7 +61,7 @@ const Trex = require('../../assets/trex.png');
                 <img pxb-primary [src]="trex" alt="A T-Rex as the avatar image" />
             </pxb-hero>
             <pxb-hero label="progress icon" value="72px" iconSize="72" [iconBackgroundColor]="colors.white[50]">
-                <battery-progress pxb-primary size="72" [color]="colors.green[500]" percent="92"></battery-progress>
+                <battery-progress pxb-primary [color]="colors.green[500]" percent="92"></battery-progress>
             </pxb-hero>
         </pxb-hero-banner>
     `,

--- a/demos/storybook/stories/hero/different-image-types.component.ts
+++ b/demos/storybook/stories/hero/different-image-types.component.ts
@@ -4,7 +4,7 @@ import { BrowserModule, DomSanitizer } from '@angular/platform-browser';
 import { HeroModule } from '@pxblue/angular-components';
 import * as Colors from '@pxblue/colors';
 import { HttpClientModule } from '@angular/common/http';
-import {NgProgressIconsModule} from "@pxblue/ng-progress-icons";
+import { NgProgressIconsModule } from '@pxblue/ng-progress-icons';
 const iconSet = require('@pxblue/icons-svg/icons.svg');
 const Trex = require('../../assets/trex.png');
 

--- a/demos/storybook/yarn.lock
+++ b/demos/storybook/yarn.lock
@@ -1570,6 +1570,13 @@
   resolved "https://registry.yarnpkg.com/@pxblue/icons/-/icons-1.0.25.tgz#52d22a987f168840ae7bdafb065f52c3ad5396da"
   integrity sha512-Q1+wgCjRpX5TeOY8JPpea1yF4uZOCsISQuguRcRIgqthAWH//Jcq4zCKMeOYLHjmXUU7RbWKv4PaA91//xPekQ==
 
+"@pxblue/ng-progress-icons@^1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@pxblue/ng-progress-icons/-/ng-progress-icons-1.1.4.tgz#02e3051d8d0d7be33deedccd603c033f17e1dd8c"
+  integrity sha512-s3O4DINjeCUAXRWPMTqsbK9cTUEockb0/+MG7rsXoVur+ef9FDu1QQHVRC8jG6/+cB6LGt96Di8yFgCixQEQ4A==
+  dependencies:
+    tslib "^1.9.0"
+
 "@pxblue/prettier-config@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@pxblue/prettier-config/-/prettier-config-1.0.2.tgz#fb00503df6557b66c3d91d43c9101e614c35d2ec"


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #113 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Remove the 4px padding on the primary icon
- Fix nested styling so progress icons fill appropriately.
- Fix nested styling so progress icon size doesn't need to be provided if Hero `iconSize` is provided.
- Add new icon type to the Hero storybook demo

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:

This battery used to be full: 
![image](https://user-images.githubusercontent.com/6538289/87819687-a4659300-c83a-11ea-91f3-de9ac1655fa3.png)

New progress icon demo added to this story: 
![image](https://user-images.githubusercontent.com/6538289/87819702-adeefb00-c83a-11ea-9326-15f838ee9418.png)

