### PR TITLE
Make it so that the drawer text wont show when the drawer is closed

### DIFF
--- a/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.scss
+++ b/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.scss
@@ -43,6 +43,11 @@ pxb-drawer-nav-item {
         .mat-list-text {
             padding-left: 0px !important; //TODO: Remove the !important, use higher specificity.
         }
+
+        // This class is used to hide a nav-item's clipped title when collapsed with no icon.
+        &.no-icon-closed .pxb-info-list-item .mat-list-item-content {
+            padding-right: 24px;
+        }
     }
 
     .pxb-info-list-item .pxb-info-list-item-icon-wrapper {

--- a/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.ts
+++ b/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.ts
@@ -48,6 +48,7 @@ export type ActiveItemBackgroundShape = 'round' | 'square';
                 [class.pxb-info-list-item-active]="selected"
                 [class.round]="activeItemBackgroundShape === 'round'"
                 [class.square]="activeItemBackgroundShape === 'square' || !drawerOpen"
+                [class.no-icon-closed]="isEmpty(iconEl) && !drawerOpen"
                 [matRippleDisabled]="!ripple"
                 matRipple
             >
@@ -102,6 +103,7 @@ export class DrawerNavItemComponent extends StateListener implements Omit<Drawer
     @Output() select: EventEmitter<string> = new EventEmitter<string>();
 
     @ContentChildren(DrawerNavItemComponent, { descendants: false }) nestedNavItems;
+    @ViewChild('icon', { static: false }) iconEl: ElementRef;
     @ViewChild('expandIcon', { static: false }) expandIconEl: ElementRef;
     @ViewChild('collapseIcon', { static: false }) collapseIconEl: ElementRef;
 

--- a/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.ts
+++ b/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.ts
@@ -48,7 +48,7 @@ export type ActiveItemBackgroundShape = 'round' | 'square';
                 [class.pxb-info-list-item-active]="selected"
                 [class.round]="activeItemBackgroundShape === 'round'"
                 [class.square]="activeItemBackgroundShape === 'square' || !isOpen()"
-                [class.no-icon-closed]="isEmpty(iconEl) && !drawerOpen"
+                [class.no-icon-closed]="isEmpty(iconEl) && !isOpen()"
                 [matRippleDisabled]="!ripple"
                 matRipple
             >
@@ -104,6 +104,7 @@ export class DrawerNavItemComponent extends StateListener implements Omit<Drawer
 
     @ContentChildren(DrawerNavItemComponent, { descendants: false }) nestedNavItems;
     @ViewChild('expandIcon', { static: false }) expandIconEl: ElementRef;
+    @ViewChild('icon', { static: false }) iconEl: ElementRef;
     @ViewChild('collapseIcon', { static: false }) collapseIconEl: ElementRef;
 
     isEmpty = (el: ElementRef): boolean => isEmptyView(el);

--- a/demos/storybook/stories/drawer/with-multiple-nav-groups.stories.ts
+++ b/demos/storybook/stories/drawer/with-multiple-nav-groups.stories.ts
@@ -35,7 +35,7 @@ export const withMultiNavGroups = (): any => ({
               <pxb-spacer *ngIf="spacer"></pxb-spacer> 
               <pxb-drawer-nav-group [title]="groupTitle2" [divider]="true">
                  <pxb-drawer-nav-item *ngFor="let navItem of navItems2"
-                    [title]="navItem.title"
+                    [title]="state.open ? navItem.title : ''"
                     [hidePadding]="true"
                     [selected]="state.selected === navItem.title"
                     (select)="navItem.onSelect(); setActive(navItem.title, state);">

--- a/demos/storybook/stories/drawer/with-multiple-nav-groups.stories.ts
+++ b/demos/storybook/stories/drawer/with-multiple-nav-groups.stories.ts
@@ -6,11 +6,13 @@ export const navItems2 = [
     {
         title: 'Contact',
         itemID: 'group2_item1',
+        icon: 'contact_page',
         onSelect: action('Contact'),
     },
     {
         title: 'Favorites',
         itemID: 'group2_item2',
+        icon: 'favorite',
         onSelect: action('Selected: Favorites'),
     },
 ];
@@ -35,7 +37,7 @@ export const withMultiNavGroups = (): any => ({
               <pxb-spacer *ngIf="spacer"></pxb-spacer> 
               <pxb-drawer-nav-group [title]="groupTitle2" [divider]="true">
                  <pxb-drawer-nav-item *ngFor="let navItem of navItems2"
-                    [title]="state.open ? navItem.title : ''"
+                    [title]="navItem.title"
                     [hidePadding]="true"
                     [selected]="state.selected === navItem.title"
                     (select)="navItem.onSelect(); setActive(navItem.title, state);">
@@ -47,8 +49,8 @@ export const withMultiNavGroups = (): any => ({
     props: {
         navItems1: navItems,
         navItems2: navItems2,
-        groupTitle1: text('NavGroup 1 title', 'Group 1 (with icons)'),
-        groupTitle2: text('NavGroup 2 title', 'Group 2 (no icons)'),
+        groupTitle1: text('NavGroup 1 title', 'Group 1'),
+        groupTitle2: text('NavGroup 2 title', 'Group 2'),
         spacer: boolean('Add Spacer', false),
     },
 });


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #126 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- When the drawer is closed, the nav-items with no icons are set to hide.


An alternative solution would be to make this drawer non-closable. 

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
![image](https://user-images.githubusercontent.com/6538289/89433375-40830b80-d710-11ea-91d6-9d1ac031f4cf.png)

![image](https://user-images.githubusercontent.com/6538289/89433445-5395db80-d710-11ea-970f-9c1bdfcb46b8.png)


