### PR TITLE
Update state management logic

### DIFF
--- a/components/src/core/drawer/drawer-body/drawer-body.component.ts
+++ b/components/src/core/drawer/drawer-body/drawer-body.component.ts
@@ -7,7 +7,7 @@ import { DrawerService } from '../service/drawer.service';
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     template: `
-        <div class="pxb-drawer-body" [class.pxb-drawer-body-closed]="!drawerOpen">
+        <div class="pxb-drawer-body" [class.pxb-drawer-body-closed]="!isOpen()">
             <ng-content></ng-content>
         </div>
     `,

--- a/components/src/core/drawer/drawer-body/nav-group/drawer-nav-group.component.spec.ts
+++ b/components/src/core/drawer/drawer-body/nav-group/drawer-nav-group.component.spec.ts
@@ -29,21 +29,21 @@ describe('DrawerNavGroupComponent', () => {
 
     it('should render the title if the drawer is open', () => {
         component.title = 'test';
-        component.drawerOpen = true;
+        spyOn(component, 'isOpen').and.returnValue(true);
         fixture.detectChanges();
         void expect(fixture.nativeElement.querySelector('.pxb-drawer-nav-group-title').innerHTML).toContain('test');
     });
 
     it('should hide the group title if the drawer is not open', () => {
         component.title = 'test';
-        component.drawerOpen = false;
+        spyOn(component, 'isOpen').and.returnValue(false);
         fixture.detectChanges();
         void expect(fixture.nativeElement.querySelector('.pxb-drawer-nav-group-title-closed')).toBeTruthy();
     });
 
     it('should enforce class naming conventions', () => {
         component.title = 'test';
-        component.drawerOpen = true;
+        spyOn(component, 'isOpen').and.returnValue(true);
         fixture.detectChanges();
         const classList = ['.pxb-drawer-nav-group', '.pxb-drawer-nav-group-title'];
         for (const className of classList) {

--- a/components/src/core/drawer/drawer-body/nav-group/drawer-nav-group.component.ts
+++ b/components/src/core/drawer/drawer-body/nav-group/drawer-nav-group.component.ts
@@ -37,11 +37,7 @@ import { StateListener } from '../../state-listener.component';
     ],
     template: `
         <div class="pxb-drawer-nav-group">
-            <div
-                *ngIf="title"
-                class="pxb-drawer-nav-group-title"
-                [class.pxb-drawer-nav-group-title-closed]="!drawerOpen"
-            >
+            <div *ngIf="title" class="pxb-drawer-nav-group-title" [class.pxb-drawer-nav-group-title-closed]="!isOpen()">
                 {{ title }}
             </div>
             <ng-content select="pxb-title-content"></ng-content>

--- a/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.spec.ts
+++ b/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.spec.ts
@@ -37,7 +37,7 @@ describe('DrawerNavItemComponent', () => {
 
     it('should enforce class naming conventions', () => {
         component.hasChildren = true;
-        component.drawerOpen = true;
+        spyOn(component, 'isOpen').and.returnValue(true);
         spyOn(component, 'ngAfterContentInit').and.stub();
         fixture.detectChanges();
         const classList = ['.pxb-drawer-nav-item', '.pxb-drawer-nav-item-expand-icon', '.pxb-drawer-nested-nav-item'];

--- a/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.ts
+++ b/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.ts
@@ -107,7 +107,6 @@ export class DrawerNavItemComponent extends StateListener implements Omit<Drawer
 
     isEmpty = (el: ElementRef): boolean => isEmptyView(el);
     isNestedItem: boolean;
-    drawerOpen: boolean;
     hasChildren = false;
     depth: number;
     id: number;
@@ -135,8 +134,7 @@ export class DrawerNavItemComponent extends StateListener implements Omit<Drawer
     }
 
     listenForDrawerChanges(): void {
-        this.drawerOpenListener = this.drawerService.drawerOpenChanges().subscribe((res: boolean) => {
-            this.drawerOpen = res;
+        this.drawerOpenListener = this.drawerService.drawerOpenChanges().subscribe(() => {
             // Two detections are required to get the custom icons to work.
             // First tick causes the icons to container to reappear.
             // Second tick handles isEmpty function calls.

--- a/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.ts
+++ b/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.ts
@@ -42,12 +42,12 @@ export type ActiveItemBackgroundShape = 'round' | 'square';
                 (click)="selectItem()"
                 [dense]="true"
                 [statusColor]="statusColor"
-                [chevron]="chevron && drawerOpen"
+                [chevron]="chevron && isOpen()"
                 [hidePadding]="hidePadding"
                 [divider]="divider ? 'full' : undefined"
                 [class.pxb-info-list-item-active]="selected"
                 [class.round]="activeItemBackgroundShape === 'round'"
-                [class.square]="activeItemBackgroundShape === 'square' || !drawerOpen"
+                [class.square]="activeItemBackgroundShape === 'square' || !isOpen()"
                 [matRippleDisabled]="!ripple"
                 matRipple
             >
@@ -63,7 +63,7 @@ export type ActiveItemBackgroundShape = 'round' | 'square';
                     {{ title }}
                 </div>
                 <div pxb-subtitle>{{ subtitle }}</div>
-                <div pxb-right-content *ngIf="hasChildren && drawerOpen">
+                <div pxb-right-content *ngIf="hasChildren && isOpen()">
                     <div #expandIcon *ngIf="!expanded">
                         <ng-content select="[pxb-expand-icon]"></ng-content>
                     </div>
@@ -81,7 +81,7 @@ export type ActiveItemBackgroundShape = 'round' | 'square';
         </div>
         <!-- Nested Nav Items -->
         <mat-accordion displayMode="flat" class="pxb-drawer-nested-nav-item">
-            <mat-expansion-panel [expanded]="expanded && drawerOpen">
+            <mat-expansion-panel [expanded]="expanded && isOpen()">
                 <ng-content select="pxb-drawer-nav-item"></ng-content>
             </mat-expansion-panel>
         </mat-accordion>

--- a/components/src/core/drawer/drawer-footer/drawer-footer.component.ts
+++ b/components/src/core/drawer/drawer-footer/drawer-footer.component.ts
@@ -7,7 +7,7 @@ import { StateListener } from '../state-listener.component';
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     template: `
-        <div class="pxb-drawer-footer" [class.pxb-drawer-footer-closed]="!drawerOpen">
+        <div class="pxb-drawer-footer" [class.pxb-drawer-footer-closed]="!isOpen()">
             <mat-divider *ngIf="divider"></mat-divider>
             <ng-content></ng-content>
         </div>

--- a/components/src/core/drawer/drawer-header/drawer-header.component.spec.ts
+++ b/components/src/core/drawer/drawer-header/drawer-header.component.spec.ts
@@ -58,7 +58,6 @@ describe('DrawerHeaderComponent', () => {
     });
 
     it('should render title', () => {
-        component.drawerOpen = true;
         component.title = 'test title';
         fixture.detectChanges();
         const title = fixture.debugElement.query(By.css('.pxb-drawer-header-title'));
@@ -66,7 +65,6 @@ describe('DrawerHeaderComponent', () => {
     });
 
     it('should render subtitle', () => {
-        component.drawerOpen = true;
         component.title = 'test title';
         component.subtitle = 'test subtitle';
         fixture.detectChanges();
@@ -93,7 +91,6 @@ describe('DrawerHeaderComponent', () => {
     it('should enforce class naming conventions', () => {
         component.title = 'test title';
         component.subtitle = 'test subtitle';
-        component.drawerOpen = true;
         fixture.detectChanges();
         const classList = [
             '.pxb-drawer-header',

--- a/components/src/core/drawer/drawer-layout/drawer-layout.component.ts
+++ b/components/src/core/drawer/drawer-layout/drawer-layout.component.ts
@@ -26,7 +26,7 @@ export type DrawerLayoutVariantType = 'permanent' | 'persistent' | 'temporary';
                 [class.smooth]="variant !== 'temporary' && transition"
                 [style.width.px]="isCollapsed() ? 56 : width"
                 [mode]="getMode()"
-                [opened]="isOpen()"
+                [opened]="isDrawerVisible()"
             >
                 <ng-content select="[pxb-drawer]"></ng-content>
             </mat-sidenav>
@@ -72,10 +72,6 @@ export class DrawerLayoutComponent extends StateListener implements AfterViewIni
             this.transition = true;
         }, 400);
         this.drawerService.setDrawerVariant(this.variant);
-        if (this.variant === 'permanent') {
-            this.drawerService.setDrawerOpen(true);
-        }
-        this.changeDetector.detectChanges();
     }
 
     ngOnDestroy(): void {
@@ -93,8 +89,8 @@ export class DrawerLayoutComponent extends StateListener implements AfterViewIni
     }
 
     // Is the drawer seen on the screen and expanded.
-    isOpen(): boolean {
-        if (this.variant === 'temporary') return this.drawerOpen;
+    isDrawerVisible(): boolean {
+        if (this.variant === 'temporary') return this.isOpen();
         return true;
     }
 
@@ -107,7 +103,7 @@ export class DrawerLayoutComponent extends StateListener implements AfterViewIni
 
     // Is the drawer condensed.
     isCollapsed(): boolean {
-        if (this.variant === 'persistent') return !this.drawerOpen;
+        if (this.variant === 'persistent') return !this.isOpen();
         return false;
     }
 }

--- a/components/src/core/drawer/drawer-subheader/drawer-subheader.component.ts
+++ b/components/src/core/drawer/drawer-subheader/drawer-subheader.component.ts
@@ -7,7 +7,7 @@ import { StateListener } from '../state-listener.component';
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     template: `
-        <div class="pxb-drawer-subheader" [class.pxb-drawer-subheader-closed]="!drawerOpen">
+        <div class="pxb-drawer-subheader" [class.pxb-drawer-subheader-closed]="!isOpen()">
             <ng-content></ng-content>
         </div>
         <mat-divider *ngIf="divider"></mat-divider>

--- a/components/src/core/drawer/drawer.component.ts
+++ b/components/src/core/drawer/drawer.component.ts
@@ -16,8 +16,7 @@ import { Subscription } from 'rxjs';
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     template: `
-        <div class="pxb-drawer" [class.collapse]="!open && !tempOpen" [class.temp-variant]="isTemporaryVariant()">
-        <div class="pxb-drawer" [class.collapse]="!isOpen()">
+        <div class="pxb-drawer" [class.collapse]="!isOpen()" [class.temp-variant]="isTemporaryVariant()">
             <!-- Drawer is responsible for managing the styles between the 4 subsections -->
             <ng-content select="pxb-drawer-header"></ng-content>
             <div class="pxb-drawer-hover-area" (mouseenter)="hoverDrawer()" (mouseleave)="unhoverDrawer()">

--- a/components/src/core/drawer/drawer.component.ts
+++ b/components/src/core/drawer/drawer.component.ts
@@ -16,7 +16,7 @@ import { Subscription } from 'rxjs';
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     template: `
-        <div class="pxb-drawer" [class.collapse]="!open && !tempOpen">
+        <div class="pxb-drawer" [class.collapse]="!isOpen()">
             <!-- Drawer is responsible for managing the styles between the 4 subsections -->
             <ng-content select="pxb-drawer-header"></ng-content>
             <div class="pxb-drawer-hover-area" (mouseenter)="hoverDrawer()" (mouseleave)="unhoverDrawer()">
@@ -32,7 +32,6 @@ export class DrawerComponent extends StateListener implements OnInit, OnChanges 
     @Input() open: boolean;
 
     hoverDelay: any;
-    tempOpen = false; // Is the drawer being hovered and needs opened?
     drawerSelectionListener: Subscription;
 
     constructor(drawerService: DrawerService, changeDetectorRef: ChangeDetectorRef) {
@@ -53,8 +52,7 @@ export class DrawerComponent extends StateListener implements OnInit, OnChanges 
     hoverDrawer(): void {
         if (!this.open) {
             this.hoverDelay = setTimeout(() => {
-                this.tempOpen = true;
-                this.drawerService.setDrawerOpen(true);
+                this.drawerService.setDrawerTempOpen(true);
                 this.changeDetector.detectChanges();
             }, 500);
         }
@@ -62,9 +60,8 @@ export class DrawerComponent extends StateListener implements OnInit, OnChanges 
 
     unhoverDrawer(): void {
         clearTimeout(this.hoverDelay);
-        if (this.tempOpen) {
-            this.tempOpen = false;
-            this.drawerService.setDrawerOpen(false);
+        if (this.drawerService.isTempOpen()) {
+            this.drawerService.setDrawerTempOpen(false);
             this.changeDetector.detectChanges();
         }
     }
@@ -73,9 +70,8 @@ export class DrawerComponent extends StateListener implements OnInit, OnChanges 
     // Expanding nested navitems when temporarily opened will not close the drawer.
     listenForDrawerSelection(): void {
         this.drawerSelectionListener = this.drawerService.drawerSelectionChanges().subscribe((hasChildren) => {
-            if (this.tempOpen && !hasChildren) {
-                this.drawerService.setDrawerOpen(false);
-                this.tempOpen = false;
+            if (this.drawerService.isTempOpen() && !hasChildren) {
+                this.drawerService.setDrawerTempOpen(false);
                 this.changeDetector.detectChanges();
             }
         });

--- a/components/src/core/drawer/service/drawer.service.ts
+++ b/components/src/core/drawer/service/drawer.service.ts
@@ -9,24 +9,35 @@ export class DrawerService {
     private drawerOpen: boolean;
     private variant: DrawerLayoutVariantType;
     private navItemCount = 0;
+    private tempOpen = false;
     drawerOpenObs = new Subject<boolean>();
     drawerSelectObs = new Subject<boolean>();
 
+    setDrawerTempOpen(open: boolean): void {
+        this.tempOpen = open;
+        this.drawerOpenObs.next(this.isDrawerOpen());
+    }
+
     setDrawerOpen(drawerOpen: boolean): void {
-        this.drawerOpen = drawerOpen || this.getDrawerVariant() === 'permanent';
-        this.drawerOpenObs.next(this.drawerOpen);
+        this.drawerOpen = drawerOpen;
+        this.drawerOpenObs.next(this.isDrawerOpen());
+    }
+
+    setDrawerVariant(variant: DrawerLayoutVariantType): void {
+        this.variant = variant;
+        this.drawerOpenObs.next(this.isDrawerOpen());
     }
 
     getDrawerVariant(): DrawerLayoutVariantType {
         return this.variant;
     }
 
-    setDrawerVariant(variant: DrawerLayoutVariantType): void {
-        this.variant = variant;
+    isDrawerOpen(): boolean {
+        return this.drawerOpen || this.getDrawerVariant() === 'permanent' || this.tempOpen;
     }
 
-    isDrawerOpen(): boolean {
-        return this.drawerOpen;
+    isTempOpen(): boolean {
+        return this.tempOpen;
     }
 
     drawerOpenChanges(): Observable<boolean> {

--- a/components/src/core/drawer/state-listener.component.ts
+++ b/components/src/core/drawer/state-listener.component.ts
@@ -3,18 +3,20 @@ import { DrawerService } from './service/drawer.service';
 import { Subscription } from 'rxjs';
 
 export class StateListener implements OnInit, OnDestroy {
-    drawerOpen: boolean;
     drawerOpenListener: Subscription;
 
     constructor(protected drawerService: DrawerService, protected changeDetector: ChangeDetectorRef) {}
 
     public ngOnInit(): void {
-        this.drawerOpen = this.drawerService.isDrawerOpen();
         this.listenForDrawerChanges();
     }
 
     public ngOnDestroy(): void {
         this.unsubscribeListeners();
+    }
+
+    public isOpen(): boolean {
+        return this.drawerService.isDrawerOpen();
     }
 
     public unsubscribeListeners(): void {
@@ -24,8 +26,7 @@ export class StateListener implements OnInit, OnDestroy {
     }
 
     listenForDrawerChanges(): void {
-        this.drawerOpenListener = this.drawerService.drawerOpenChanges().subscribe((res: boolean) => {
-            this.drawerOpen = res;
+        this.drawerOpenListener = this.drawerService.drawerOpenChanges().subscribe(() => {
             this.changeDetector.detectChanges();
         });
     }

--- a/demos/showcase/src/app/app.component.ts
+++ b/demos/showcase/src/app/app.component.ts
@@ -75,7 +75,7 @@ export class AppComponent {
         if (this.variant === 'persistent' && this._viewportService.isSmall()) {
             this._stateService.setDrawerOpen(false);
         } else if (this.variant === 'temporary' && !this._viewportService.isSmall()) {
-            this._stateService.setDrawerOpen(false);
+            this._stateService.setDrawerOpen(true);
         }
 
         this.variant = this._viewportService.isSmall() ? 'temporary' : 'persistent';


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Refactor State management of the Drawer `open` prop so that our component will not override what the parent component passes in as `@Input`

