### PR TITLE
Invert svgIcons and use barley icon

### DIFF
--- a/components/src/core/hero/hero.component.scss
+++ b/components/src/core/hero/hero.component.scss
@@ -2,11 +2,8 @@
 
 /* RTL */
 [dir='rtl'] .pxb-hero {
-    .pxb-hero-primary-wrapper.pxb-hero-svgIcon svg {
-        transform-origin: top right;
-    }
     .pxb-hero-primary-wrapper {
-        &:not(.pxb-hero-svgIcon) > * {
+        > * {
             @include invert();
         }
     }

--- a/demos/storybook/stories/hero/different-image-types.component.ts
+++ b/demos/storybook/stories/hero/different-image-types.component.ts
@@ -13,7 +13,7 @@ const Trex = require('../../assets/trex.png');
     template: `
         <pxb-hero-banner>
             <pxb-hero label="SVG" value="36px" [iconBackgroundColor]="colors.white[50]">
-                <mat-icon svgIcon="px-icons:grade_a" pxb-primary [style.color]="colors.blue[500]"></mat-icon>
+                <mat-icon svgIcon="px-icons:barley" pxb-primary [style.color]="colors.blue[500]"></mat-icon>
             </pxb-hero>
             <pxb-hero label="mat icon" value="36px" [iconBackgroundColor]="colors.white[50]">
                 <mat-icon pxb-primary>schedule</mat-icon>
@@ -31,7 +31,7 @@ const Trex = require('../../assets/trex.png');
 
         <pxb-hero-banner>
             <pxb-hero label="SVG" units="px" value="48" iconSize="48" [iconBackgroundColor]="colors.white[50]">
-                <mat-icon svgIcon="px-icons:grade_a" pxb-primary [style.color]="colors.blue[500]"></mat-icon>
+                <mat-icon svgIcon="px-icons:barley" pxb-primary [style.color]="colors.blue[500]"></mat-icon>
             </pxb-hero>
             <pxb-hero label="mat icon" units="px" value="48" iconSize="48" [iconBackgroundColor]="colors.white[50]">
                 <mat-icon pxb-primary>schedule</mat-icon>
@@ -49,7 +49,7 @@ const Trex = require('../../assets/trex.png');
 
         <pxb-hero-banner>
             <pxb-hero label="SVG" value="72px" iconSize="72" [iconBackgroundColor]="colors.white[50]">
-                <mat-icon svgIcon="px-icons:grade_a" pxb-primary [style.color]="colors.blue[500]"></mat-icon>
+                <mat-icon svgIcon="px-icons:barley" pxb-primary [style.color]="colors.blue[500]"></mat-icon>
             </pxb-hero>
             <pxb-hero label="mat icon" value="72px" iconSize="72" [iconBackgroundColor]="colors.white[50]">
                 <mat-icon pxb-primary>schedule</mat-icon>


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #123 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Update icon types story to use the `barley` icon instead of `grade_a`.
- Apply invert logic to svgIcons too

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
![barley](https://user-images.githubusercontent.com/6538289/89910151-e249a300-dbbd-11ea-956b-5e9477dbf7b3.gif)
