### PR TITLE
Fix banner display settings, add border to banner story

### DIFF
--- a/components/src/core/hero/hero-banner.component.scss
+++ b/components/src/core/hero/hero-banner.component.scss
@@ -1,13 +1,18 @@
+.pxb-hero-banner-root {
+    display: flex;
+}
+
 .pxb-hero-banner {
     display: flex;
+    flex: 1 1 0;
     align-items: center;
     justify-content: center;
-}
 
-:host ::ng-deep pxb-hero:nth-child(n + 5) {
-    display: none;
-}
+    pxb-hero {
+        flex: 1 1 0;
+    }
 
-::ng-deep pxb-hero {
-    flex: 1 1 0px;
+    pxb-hero:nth-child(n + 5) {
+        display: none;
+    }
 }

--- a/components/src/core/hero/hero-banner.component.ts
+++ b/components/src/core/hero/hero-banner.component.ts
@@ -11,6 +11,9 @@ import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@a
         <mat-divider class="pxb-hero-banner-divider" *ngIf="divider"></mat-divider>
     `,
     styleUrls: ['./hero-banner.component.scss'],
+    host: {
+        class: 'pxb-hero-banner-root', // TODO: Follow ng mat naming conventions
+    },
 })
 export class HeroBannerComponent {
     @Input() divider = false;

--- a/demos/storybook/stories/hero/within-a-banner.stories.ts
+++ b/demos/storybook/stories/hero/within-a-banner.stories.ts
@@ -21,7 +21,7 @@ export const withinBanner = (): any => ({
     `,
     props: {
         count: number('count', 4, { range: true, min: 1, max: 4, step: 1 }),
-        bannerWidth: number('width', 400, { range: true, min: 300, max: 600, step: 50 }),
+        bannerWidth: number('width', 400, { range: true, min: 350, max: 600, step: 50 }),
         green: Colors.green[500],
         yellow: Colors.yellow[500],
         borderColor: Colors.gray[200],

--- a/demos/storybook/stories/hero/within-a-banner.stories.ts
+++ b/demos/storybook/stories/hero/within-a-banner.stories.ts
@@ -3,7 +3,8 @@ import * as Colors from '@pxblue/colors';
 
 export const withinBanner = (): any => ({
     template: `
-        <pxb-hero-banner>
+        <pxb-hero-banner [style.borderColor]="borderColor" [style.width.px]="bannerWidth" 
+            style="border: solid 1px; border-radius: 4px">
             <pxb-hero *ngIf="count > 0" [label]="'Health'" [value]="96" [units]="'/100'">
                 <i pxb-primary [style.color]="green" class="pxb-grade_a"></i>
             </pxb-hero>
@@ -19,8 +20,10 @@ export const withinBanner = (): any => ({
         </pxb-hero-banner>
     `,
     props: {
-        count: number('count', 4, { range: true, min: 0, max: 4, step: 1 }),
+        count: number('count', 4, { range: true, min: 1, max: 4, step: 1 }),
+        bannerWidth: number('width', 400, { range: true, min: 300, max: 600, step: 50 }),
         green: Colors.green[500],
         yellow: Colors.yellow[500],
+        borderColor: Colors.gray[200],
     },
 });


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Add width knob to HeroBanner story.
- Heroes within hero-banner all set to grow.
- Add border around HeroBanner story.

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
<img width="650" alt="Screen Shot 2020-09-01 at 2 04 53 PM" src="https://user-images.githubusercontent.com/6538289/91889643-262f4580-ec5c-11ea-80c6-fb5e0febb449.png">

