### PR TITLE
Bug/empty state padding

### DIFF
--- a/components/src/core/empty-state/empty-state.component.scss
+++ b/components/src/core/empty-state/empty-state.component.scss
@@ -28,10 +28,11 @@
     }
 
     .pxb-empty-state-empty-icon-wrapper {
+        margin-bottom: 16px;
         line-height: 1;
         > * {
             display: block;
-            font-size: 100px;
+            font-size: 96px;
             height: 100%;
             width: 100%;
             text-align: center;

--- a/components/src/core/hero/hero.component.scss
+++ b/components/src/core/hero/hero.component.scss
@@ -20,8 +20,6 @@
     padding: 16px 8px;
 
     .pxb-hero-primary-wrapper {
-        $normal: 32px;
-        $large: 72px;
         border-radius: 50%;
         margin-bottom: 5px;
         text-align: center;


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #152 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Add 16px margin under empty state icon
- Make empty state icon 96x96
