### PR TITLE
Remove icon invert logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Change Log
 
+## vX.X.X (version TBD, to be published)
+
+-   Removed right-to-left icon inverting logic per [Material Design's bidirectionality guideline](https://material.io/design/usability/bidirectionality.html#mirroring-layout).
+
 ## v2.2.0
--   Adds a new `rail` variant to the `<pxb-drawer-layout>`. 
+
+-   Adds a new `rail` variant to the `<pxb-drawer-layout>`.
 
 ## v2.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,9 @@
 # Change Log
 
-## vX.X.X (version TBD, to be published)
-
--   Removed right-to-left icon inverting logic per [Material Design's bidirectionality guideline](https://material.io/design/usability/bidirectionality.html#mirroring-layout).
-
-## v2.2.0
+## v2.2.0 (to be published)
 
 -   Adds a new `rail` variant to the `<pxb-drawer-layout>`.
+-   Removed right-to-left icon inverting logic per [Material Design's bidirectionality guideline](https://material.io/design/usability/bidirectionality.html#mirroring-layout).
 
 ## v2.1.0
 

--- a/components/src/core/channel-value/channel-value.component.scss
+++ b/components/src/core/channel-value/channel-value.component.scss
@@ -1,10 +1,7 @@
-@import '../utility/utility';
-
 /* RTL */
 [dir='rtl'] .pxb-channel-value .pxb-channel-value-icon-wrapper {
     margin-right: 0;
     margin-left: 4px;
-    @include invert();
 }
 
 .pxb-channel-value {

--- a/components/src/core/empty-state/empty-state.component.scss
+++ b/components/src/core/empty-state/empty-state.component.scss
@@ -1,10 +1,3 @@
-@import '../utility/utility';
-
-/* RTL */
-[dir='rtl'] .pxb-empty-state .pxb-empty-state-empty-icon-wrapper > * {
-    @include invert();
-}
-
 .pxb-empty-state {
     height: 100%;
     width: 100%;

--- a/components/src/core/hero/hero.component.scss
+++ b/components/src/core/hero/hero.component.scss
@@ -1,11 +1,8 @@
-@import '../utility/utility';
-
 /* RTL */
 [dir='rtl'] .pxb-hero {
     .pxb-hero-primary-wrapper {
-        > * {
-            @include invert();
-        }
+        display: flex;
+        justify-content: flex-end;
     }
 }
 

--- a/components/src/core/info-list-item/info-list-item.component.scss
+++ b/components/src/core/info-list-item/info-list-item.component.scss
@@ -124,8 +124,8 @@ $denseHeight: 52px;
         min-width: 40px;
         height: auto; /* Used to override height applied when wrapped in a mat-list. */
         margin-right: 16px;
+        padding: 0;
         &.pxb-info-list-item-hide-padding:empty {
-            padding: 0;
             width: 0;
             margin: 0;
             min-width: unset;

--- a/components/src/core/score-card/score-card.component.scss
+++ b/components/src/core/score-card/score-card.component.scss
@@ -1,10 +1,3 @@
-@import '../utility/utility';
-
-/* RTL */
-[dir='rtl'] .pxb-score-card-action-items-wrapper > * {
-    @include invert();
-}
-
 .pxb-score-card.mat-card {
     padding: 0;
 }


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #150. 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Remove the 4px padding around info list item icons
- Remvoe icon flipping logic

TODO:
- Add logic back to showcase and storybook
