### PR TITLE
Feature/112 host class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## v2.2.0 (to be published)
+## v3.0.0 (to be published)
 
 -   Adds a new `rail` variant to the `<pxb-drawer-layout>`.
 -   Removed right-to-left icon inverting logic per [Material Design's bidirectionality guideline](https://material.io/design/usability/bidirectionality.html#mirroring-layout).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 -   Adds a new `rail` variant to the `<pxb-drawer-layout>`.
 -   Removed right-to-left icon inverting logic per [Material Design's bidirectionality guideline](https://material.io/design/usability/bidirectionality.html#mirroring-layout).
+-   Adds a host class to each PX Blue component tag
 
 ## v2.1.0
 

--- a/components/src/core/channel-value/channel-value.component.scss
+++ b/components/src/core/channel-value/channel-value.component.scss
@@ -1,10 +1,14 @@
 /* RTL */
-[dir='rtl'] .pxb-channel-value .pxb-channel-value-icon-wrapper {
+[dir='rtl'] .pxb-channel-value-content .pxb-channel-value-icon-wrapper {
     margin-right: 0;
     margin-left: 4px;
 }
 
 .pxb-channel-value {
+    display: inline-flex;
+}
+
+.pxb-channel-value-content {
     display: inline-flex;
     align-items: center;
     line-height: 1.2;

--- a/components/src/core/channel-value/channel-value.component.spec.ts
+++ b/components/src/core/channel-value/channel-value.component.spec.ts
@@ -46,7 +46,7 @@ describe('ChannelValueComponent', () => {
         component.units = 'hz';
         component.prefix = false;
         fixture.detectChanges();
-        const container = fixture.nativeElement.querySelector('.pxb-channel-value');
+        const container = fixture.nativeElement.querySelector('.pxb-channel-value-content');
         const units = fixture.nativeElement.querySelector('.pxb-channel-value-units');
         void expect(units.innerHTML).toBe('hz');
         void expect(container.children[2]).toBe(units);
@@ -57,7 +57,7 @@ describe('ChannelValueComponent', () => {
         component.units = 'C';
         component.prefix = true;
         fixture.detectChanges();
-        const container = fixture.nativeElement.querySelector('.pxb-channel-value');
+        const container = fixture.nativeElement.querySelector('.pxb-channel-value-content');
         const units = fixture.nativeElement.querySelector('.pxb-channel-value-units');
         void expect(units.innerHTML).toBe('C');
         void expect(container.children[1]).toBe(units);
@@ -75,7 +75,7 @@ describe('ChannelValueComponent', () => {
         component.units = 'hz';
         fixture.detectChanges();
         const classList = [
-            '.pxb-channel-value',
+            '.pxb-channel-value-content',
             '.pxb-channel-value-units',
             '.pxb-channel-value-icon-wrapper',
             '.pxb-channel-value-value',

--- a/components/src/core/channel-value/channel-value.component.ts
+++ b/components/src/core/channel-value/channel-value.component.ts
@@ -17,7 +17,7 @@ import { requireInput } from '../../utils/utils';
     `,
     styleUrls: ['./channel-value.component.scss'],
     host: {
-        class: 'pxb-channel-value'
+        class: 'pxb-channel-value',
     },
 })
 export class ChannelValueComponent implements OnChanges {

--- a/components/src/core/channel-value/channel-value.component.ts
+++ b/components/src/core/channel-value/channel-value.component.ts
@@ -6,7 +6,7 @@ import { requireInput } from '../../utils/utils';
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     template: `
-        <span class="pxb-channel-value" [style.color]="color">
+        <span class="pxb-channel-value-content" [style.color]="color">
             <span class="pxb-channel-value-icon-wrapper">
                 <ng-content></ng-content>
             </span>
@@ -16,6 +16,9 @@ import { requireInput } from '../../utils/utils';
         </span>
     `,
     styleUrls: ['./channel-value.component.scss'],
+    host: {
+        class: 'pxb-channel-value'
+    },
 })
 export class ChannelValueComponent implements OnChanges {
     @Input() value: string | number;

--- a/components/src/core/drawer/drawer-body/drawer-body.component.spec.ts
+++ b/components/src/core/drawer/drawer-body/drawer-body.component.spec.ts
@@ -23,7 +23,7 @@ describe('DrawerBodyComponent', () => {
 
     it('should enforce class naming conventions', () => {
         fixture.detectChanges();
-        const classList = ['.pxb-drawer-body'];
+        const classList = ['.pxb-drawer-body-content'];
         for (const className of classList) {
             count(fixture, className);
         }

--- a/components/src/core/drawer/drawer-body/drawer-body.component.ts
+++ b/components/src/core/drawer/drawer-body/drawer-body.component.ts
@@ -24,7 +24,7 @@ import { DrawerService } from '../service/drawer.service';
         `,
     ],
     host: {
-        class: 'pxb-drawer-body'
+        class: 'pxb-drawer-body',
     },
 })
 export class DrawerBodyComponent extends StateListener {

--- a/components/src/core/drawer/drawer-body/drawer-body.component.ts
+++ b/components/src/core/drawer/drawer-body/drawer-body.component.ts
@@ -7,13 +7,13 @@ import { DrawerService } from '../service/drawer.service';
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     template: `
-        <div class="pxb-drawer-body" [class.pxb-drawer-body-closed]="!isOpen()">
+        <div class="pxb-drawer-body-content" [class.pxb-drawer-body-closed]="!isOpen()">
             <ng-content></ng-content>
         </div>
     `,
     styles: [
         `
-            .pxb-drawer-body {
+            .pxb-drawer-body-content {
                 height: 100%;
                 display: flex;
                 flex-direction: column;
@@ -23,6 +23,9 @@ import { DrawerService } from '../service/drawer.service';
             }
         `,
     ],
+    host: {
+        class: 'pxb-drawer-body'
+    },
 })
 export class DrawerBodyComponent extends StateListener {
     constructor(drawerService: DrawerService, changeDetectorRef: ChangeDetectorRef) {

--- a/components/src/core/drawer/drawer-body/nav-group/drawer-nav-group.component.spec.ts
+++ b/components/src/core/drawer/drawer-body/nav-group/drawer-nav-group.component.spec.ts
@@ -45,7 +45,7 @@ describe('DrawerNavGroupComponent', () => {
         component.title = 'test';
         spyOn(component, 'isOpen').and.returnValue(true);
         fixture.detectChanges();
-        const classList = ['.pxb-drawer-nav-group', '.pxb-drawer-nav-group-title'];
+        const classList = ['.pxb-drawer-nav-group-content', '.pxb-drawer-nav-group-title'];
         for (const className of classList) {
             count(fixture, className);
         }

--- a/components/src/core/drawer/drawer-body/nav-group/drawer-nav-group.component.ts
+++ b/components/src/core/drawer/drawer-body/nav-group/drawer-nav-group.component.ts
@@ -15,7 +15,7 @@ import { StateListener } from '../../state-listener.component';
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     styles: [
-        `            
+        `
             .pxb-drawer-nav-group-content .mat-list-base {
                 font-weight: 600;
                 padding-top: 0;
@@ -48,7 +48,7 @@ import { StateListener } from '../../state-listener.component';
         </div>
     `,
     host: {
-        class: 'pxb-drawer-nav-group'
+        class: 'pxb-drawer-nav-group',
     },
 })
 export class DrawerNavGroupComponent extends StateListener implements Omit<DrawerNavGroup, 'items'> {

--- a/components/src/core/drawer/drawer-body/nav-group/drawer-nav-group.component.ts
+++ b/components/src/core/drawer/drawer-body/nav-group/drawer-nav-group.component.ts
@@ -15,12 +15,12 @@ import { StateListener } from '../../state-listener.component';
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     styles: [
-        `
-            .pxb-drawer-nav-group .mat-list-base {
+        `            
+            .pxb-drawer-nav-group-content .mat-list-base {
                 font-weight: 600;
                 padding-top: 0;
             }
-            .pxb-drawer-nav-group .pxb-drawer-nav-group-title {
+            .pxb-drawer-nav-group-content .pxb-drawer-nav-group-title {
                 font-weight: 600;
                 height: 48px;
                 line-height: 48px;
@@ -30,13 +30,13 @@ import { StateListener } from '../../state-listener.component';
                 text-overflow: ellipsis;
                 display: block;
             }
-            .pxb-drawer-nav-group .pxb-drawer-nav-group-title-closed {
+            .pxb-drawer-nav-group-content .pxb-drawer-nav-group-title-closed {
                 visibility: hidden;
             }
         `,
     ],
     template: `
-        <div class="pxb-drawer-nav-group">
+        <div class="pxb-drawer-nav-group-content">
             <div *ngIf="title" class="pxb-drawer-nav-group-title" [class.pxb-drawer-nav-group-title-closed]="!isOpen()">
                 {{ title }}
             </div>
@@ -47,6 +47,9 @@ import { StateListener } from '../../state-listener.component';
             </mat-nav-list>
         </div>
     `,
+    host: {
+        class: 'pxb-drawer-nav-group'
+    },
 })
 export class DrawerNavGroupComponent extends StateListener implements Omit<DrawerNavGroup, 'items'> {
     @Input() title: string;

--- a/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.scss
+++ b/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.scss
@@ -1,4 +1,3 @@
-
 /* RTL */
 [dir='rtl'] .pxb-drawer-nav-item-content {
     .pxb-drawer-nav-item-active-highlight {

--- a/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.scss
+++ b/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.scss
@@ -1,5 +1,6 @@
+
 /* RTL */
-[dir='rtl'] .pxb-drawer-nav-item {
+[dir='rtl'] .pxb-drawer-nav-item-content {
     .pxb-drawer-nav-item-active-highlight {
         right: 0;
         &.round {
@@ -20,7 +21,7 @@ pxb-drawer-nav-item {
     outline: none;
 }
 
-.pxb-drawer-nav-item {
+.pxb-drawer-nav-item-content {
     overflow: hidden;
     position: relative;
     user-select: none;

--- a/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.spec.ts
+++ b/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.spec.ts
@@ -40,7 +40,7 @@ describe('DrawerNavItemComponent', () => {
         spyOn(component, 'isOpen').and.returnValue(true);
         spyOn(component, 'ngAfterContentInit').and.stub();
         fixture.detectChanges();
-        const classList = ['.pxb-drawer-nav-item', '.pxb-drawer-nav-item-expand-icon', '.pxb-drawer-nested-nav-item'];
+        const classList = ['.pxb-drawer-nav-item-content', '.pxb-drawer-nav-item-expand-icon', '.pxb-drawer-nested-nav-item'];
         for (const className of classList) {
             count(fixture, className);
         }

--- a/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.spec.ts
+++ b/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.spec.ts
@@ -40,7 +40,11 @@ describe('DrawerNavItemComponent', () => {
         spyOn(component, 'isOpen').and.returnValue(true);
         spyOn(component, 'ngAfterContentInit').and.stub();
         fixture.detectChanges();
-        const classList = ['.pxb-drawer-nav-item-content', '.pxb-drawer-nav-item-expand-icon', '.pxb-drawer-nested-nav-item'];
+        const classList = [
+            '.pxb-drawer-nav-item-content',
+            '.pxb-drawer-nav-item-expand-icon',
+            '.pxb-drawer-nested-nav-item',
+        ];
         for (const className of classList) {
             count(fixture, className);
         }

--- a/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.ts
+++ b/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.ts
@@ -99,7 +99,7 @@ export type ActiveItemBackgroundShape = 'round' | 'square';
         </mat-accordion>
     `,
     host: {
-        class: 'pxb-drawer-nav-item'
+        class: 'pxb-drawer-nav-item',
     },
 })
 export class DrawerNavItemComponent extends StateListener implements Omit<DrawerNavItem, 'items'> {

--- a/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.ts
+++ b/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.ts
@@ -39,7 +39,7 @@ export type ActiveItemBackgroundShape = 'round' | 'square';
     styleUrls: ['./drawer-nav-item.component.scss'],
     template: `
         <ng-template #navIcon><ng-content select="[pxb-icon]"></ng-content></ng-template>
-        <div class="pxb-drawer-nav-item" [class.pxb-drawer-nav-item-active]="selected">
+        <div class="pxb-drawer-nav-item-content" [class.pxb-drawer-nav-item-active]="selected">
             <div
                 matRipple
                 [class.pxb-drawer-nav-item-active-highlight]="selected"
@@ -98,6 +98,9 @@ export type ActiveItemBackgroundShape = 'round' | 'square';
             </mat-expansion-panel>
         </mat-accordion>
     `,
+    host: {
+        class: 'pxb-drawer-nav-item'
+    },
 })
 export class DrawerNavItemComponent extends StateListener implements Omit<DrawerNavItem, 'items'> {
     @Input() activeItemBackgroundShape: ActiveItemBackgroundShape = 'round';

--- a/components/src/core/drawer/drawer-footer/drawer-footer.component.scss
+++ b/components/src/core/drawer/drawer-footer/drawer-footer.component.scss
@@ -1,4 +1,4 @@
-.pxb-drawer-footer {
+.pxb-drawer-footer-content {
     display: flex;
     flex-direction: column;
     overflow: hidden;

--- a/components/src/core/drawer/drawer-footer/drawer-footer.component.spec.ts
+++ b/components/src/core/drawer/drawer-footer/drawer-footer.component.spec.ts
@@ -47,7 +47,7 @@ describe('DrawerFooterComponent', () => {
     it('should enforce class naming conventions', () => {
         const customFixture = TestBed.createComponent(TestDrawerFooter);
         customFixture.detectChanges();
-        const classList = ['.pxb-drawer-footer', '.pxb-drawer-footer-closed'];
+        const classList = ['.pxb-drawer-footer-content', '.pxb-drawer-footer-closed'];
         for (const className of classList) {
             count(customFixture, className);
         }

--- a/components/src/core/drawer/drawer-footer/drawer-footer.component.ts
+++ b/components/src/core/drawer/drawer-footer/drawer-footer.component.ts
@@ -14,7 +14,7 @@ import { StateListener } from '../state-listener.component';
     `,
     styleUrls: ['./drawer-footer.component.scss'],
     host: {
-        class: 'pxb-drawer-footer'
+        class: 'pxb-drawer-footer',
     },
 })
 export class DrawerFooterComponent extends StateListener {

--- a/components/src/core/drawer/drawer-footer/drawer-footer.component.ts
+++ b/components/src/core/drawer/drawer-footer/drawer-footer.component.ts
@@ -7,12 +7,15 @@ import { StateListener } from '../state-listener.component';
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     template: `
-        <div class="pxb-drawer-footer" [class.pxb-drawer-footer-closed]="!isOpen()">
+        <div class="pxb-drawer-footer-content" [class.pxb-drawer-footer-closed]="!isOpen()">
             <mat-divider *ngIf="divider"></mat-divider>
             <ng-content></ng-content>
         </div>
     `,
     styleUrls: ['./drawer-footer.component.scss'],
+    host: {
+        class: 'pxb-drawer-footer'
+    },
 })
 export class DrawerFooterComponent extends StateListener {
     @Input() divider = true;

--- a/components/src/core/drawer/drawer-header/drawer-header.component.scss
+++ b/components/src/core/drawer/drawer-header/drawer-header.component.scss
@@ -1,5 +1,5 @@
 /* RTL */
-[dir='rtl'] .pxb-drawer-header {
+[dir='rtl'] .pxb-drawer-header-content {
     .pxb-drawer-header-icon-wrapper {
         margin-right: 0;
         margin-left: 16px;
@@ -11,13 +11,14 @@
 }
 
 $height: 64px;
-.pxb-drawer-header {
+.pxb-drawer-header-content {
     width: 100%;
     align-items: flex-start;
     box-sizing: border-box;
     position: relative;
     height: $height;
     overflow: hidden;
+    display: flex;
 
     &.mat-toolbar-single-row.mat-toolbar {
         padding-right: 8px;
@@ -44,7 +45,7 @@ $height: 64px;
         bottom: 0;
     }
 
-    .pxb-drawer-header-content {
+    .pxb-drawer-header-text {
         z-index: 2;
         display: flex;
         width: 100%;

--- a/components/src/core/drawer/drawer-header/drawer-header.component.spec.ts
+++ b/components/src/core/drawer/drawer-header/drawer-header.component.spec.ts
@@ -93,7 +93,7 @@ describe('DrawerHeaderComponent', () => {
         component.subtitle = 'test subtitle';
         fixture.detectChanges();
         const classList = [
-            '.pxb-drawer-header',
+            '.pxb-drawer-header-content',
             '.pxb-drawer-header-background',
             '.pxb-drawer-header-content',
             '.pxb-drawer-header-icon-wrapper',

--- a/components/src/core/drawer/drawer-header/drawer-header.component.ts
+++ b/components/src/core/drawer/drawer-header/drawer-header.component.ts
@@ -17,12 +17,12 @@ import { isEmptyView } from '../../../utils/utils';
     encapsulation: ViewEncapsulation.None,
     template: `
         <mat-toolbar
-            class="pxb-drawer-header"
+            class="pxb-drawer-header-content"
             [class.rail]="isRail()"
             [class.pxb-drawer-header-no-icon]="isEmpty(iconEl)"
         >
             <div class="pxb-drawer-header-background"></div>
-            <div class="pxb-drawer-header-content">
+            <div class="pxb-drawer-header-text">
                 <div #icon class="pxb-drawer-header-icon-wrapper">
                     <ng-content select="[pxb-icon]"></ng-content>
                 </div>
@@ -36,6 +36,9 @@ import { isEmptyView } from '../../../utils/utils';
         <mat-divider></mat-divider>
     `,
     styleUrls: ['./drawer-header.component.scss'],
+    host: {
+        class: 'pxb-drawer-header'
+    },
 })
 export class DrawerHeaderComponent extends StateListener {
     @Input() subtitle: string;

--- a/components/src/core/drawer/drawer-header/drawer-header.component.ts
+++ b/components/src/core/drawer/drawer-header/drawer-header.component.ts
@@ -37,7 +37,7 @@ import { isEmptyView } from '../../../utils/utils';
     `,
     styleUrls: ['./drawer-header.component.scss'],
     host: {
-        class: 'pxb-drawer-header'
+        class: 'pxb-drawer-header',
     },
 })
 export class DrawerHeaderComponent extends StateListener {

--- a/components/src/core/drawer/drawer-layout/drawer-layout.component.scss
+++ b/components/src/core/drawer/drawer-layout/drawer-layout.component.scss
@@ -1,14 +1,20 @@
 $transition: 300ms cubic-bezier(0.4, 0, 0.2, 1);
 
+.pxb-drawer-layout {
+    display: flex;
+    height: 100%;
+}
+
 /* RTL */
-[dir='rtl'] .pxb-drawer-layout .mat-drawer-side {
+[dir='rtl'] .pxb-drawer-layout-content .mat-drawer-side {
     border-left: 0; // Border-left is provided by the Drawer component.
 }
 
-.pxb-drawer-layout {
+.pxb-drawer-layout-content {
     height: 100%;
     width: 100%;
     transition: none;
+    display: flex;
 
     mat-sidenav-content {
         // Do not let angular material control the margin.  They will attempt to apply their own margin even though we are calculating our own.
@@ -19,7 +25,7 @@ $transition: 300ms cubic-bezier(0.4, 0, 0.2, 1);
         border-right: none;
     }
 
-    .pxb-drawer {
+    .pxb-drawer-content {
         transition: none;
         width: 100%;
         &.collapse {

--- a/components/src/core/drawer/drawer-layout/drawer-layout.component.spec.ts
+++ b/components/src/core/drawer/drawer-layout/drawer-layout.component.spec.ts
@@ -53,7 +53,7 @@ describe('DrawerLayoutComponent', () => {
     it('should enforce class naming conventions', () => {
         const customFixture = TestBed.createComponent(DrawerRenderTest);
         customFixture.detectChanges();
-        const classList = ['.pxb-drawer-layout', '.pxb-drawer-layout-sidenav'];
+        const classList = ['.pxb-drawer-layout-content', '.pxb-drawer-layout-sidenav'];
         for (const className of classList) {
             count(customFixture, className);
         }

--- a/components/src/core/drawer/drawer-layout/drawer-layout.component.ts
+++ b/components/src/core/drawer/drawer-layout/drawer-layout.component.ts
@@ -42,7 +42,7 @@ export type DrawerLayoutVariantType = 'permanent' | 'persistent' | 'temporary' |
         </mat-sidenav-container>
     `,
     host: {
-        class: 'pxb-drawer-layout'
+        class: 'pxb-drawer-layout',
     },
 })
 export class DrawerLayoutComponent extends StateListener implements AfterViewInit, OnChanges {

--- a/components/src/core/drawer/drawer-layout/drawer-layout.component.ts
+++ b/components/src/core/drawer/drawer-layout/drawer-layout.component.ts
@@ -20,7 +20,7 @@ export type DrawerLayoutVariantType = 'permanent' | 'persistent' | 'temporary' |
     encapsulation: ViewEncapsulation.None,
     styleUrls: ['./drawer-layout.component.scss'],
     template: `
-        <mat-sidenav-container class="pxb-drawer-layout" (backdropClick)="closeDrawer()" autosize="false">
+        <mat-sidenav-container class="pxb-drawer-layout-content" (backdropClick)="closeDrawer()" autosize="false">
             <mat-sidenav
                 class="pxb-drawer-layout-sidenav"
                 [fixedInViewport]="false"
@@ -41,6 +41,9 @@ export type DrawerLayoutVariantType = 'permanent' | 'persistent' | 'temporary' |
             </div>
         </mat-sidenav-container>
     `,
+    host: {
+        class: 'pxb-drawer-layout'
+    },
 })
 export class DrawerLayoutComponent extends StateListener implements AfterViewInit, OnChanges {
     @Input() variant: DrawerLayoutVariantType;

--- a/components/src/core/drawer/drawer-subheader/drawer-subheader.component.scss
+++ b/components/src/core/drawer/drawer-subheader/drawer-subheader.component.scss
@@ -1,4 +1,5 @@
-.pxb-drawer-subheader {
+.pxb-drawer-subheader-content {
+    display: flex;
     box-sizing: border-box;
     overflow: hidden;
     &.pxb-drawer-subheader-closed {

--- a/components/src/core/drawer/drawer-subheader/drawer-subheader.component.spec.ts
+++ b/components/src/core/drawer/drawer-subheader/drawer-subheader.component.spec.ts
@@ -47,7 +47,7 @@ describe('DrawerSubheaderComponent', () => {
     it('should enforce class naming conventions', () => {
         const customFixture = TestBed.createComponent(TestDrawerSubheader);
         customFixture.detectChanges();
-        const classList = ['.pxb-drawer-subheader'];
+        const classList = ['.pxb-drawer-subheader', '.pxb-drawer-subheader-content'];
         for (const className of classList) {
             count(customFixture, className);
         }

--- a/components/src/core/drawer/drawer-subheader/drawer-subheader.component.ts
+++ b/components/src/core/drawer/drawer-subheader/drawer-subheader.component.ts
@@ -7,12 +7,15 @@ import { StateListener } from '../state-listener.component';
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     template: `
-        <div class="pxb-drawer-subheader" [class.pxb-drawer-subheader-closed]="!isOpen()">
+        <div class="pxb-drawer-subheader-content" [class.pxb-drawer-subheader-closed]="!isOpen()">
             <ng-content></ng-content>
         </div>
         <mat-divider *ngIf="divider"></mat-divider>
     `,
     styleUrls: ['./drawer-subheader.component.scss'],
+    host: {
+        class: 'pxb-drawer-subheader'
+    },
 })
 export class DrawerSubheaderComponent extends StateListener {
     @Input() divider = true;

--- a/components/src/core/drawer/drawer-subheader/drawer-subheader.component.ts
+++ b/components/src/core/drawer/drawer-subheader/drawer-subheader.component.ts
@@ -14,7 +14,7 @@ import { StateListener } from '../state-listener.component';
     `,
     styleUrls: ['./drawer-subheader.component.scss'],
     host: {
-        class: 'pxb-drawer-subheader'
+        class: 'pxb-drawer-subheader',
     },
 })
 export class DrawerSubheaderComponent extends StateListener {

--- a/components/src/core/drawer/drawer.component.scss
+++ b/components/src/core/drawer/drawer.component.scss
@@ -2,8 +2,13 @@ $width-open: 360px;
 $width-closed: 56px;
 $transition: width 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 
+.pxb-drawer {
+    height: 100%;
+    display: flex;
+}
+
 /* RTL */
-[dir='rtl'] .pxb-drawer {
+[dir='rtl'] .pxb-drawer-content {
     border-right: 0;
     border-left: 1px solid rgba(0, 0, 0, 0.12);
     &.temp-variant {
@@ -11,7 +16,7 @@ $transition: width 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
     }
 }
 
-.pxb-drawer {
+.pxb-drawer-content {
     display: flex;
     flex-direction: column;
     height: 100%;

--- a/components/src/core/drawer/drawer.component.spec.ts
+++ b/components/src/core/drawer/drawer.component.spec.ts
@@ -95,7 +95,7 @@ describe('DrawerComponent', () => {
 
     it('should enforce class naming conventions', () => {
         fixture.detectChanges();
-        const classList = ['.pxb-drawer', '.pxb-drawer-hover-area'];
+        const classList = ['.pxb-drawer-content', '.pxb-drawer-hover-area'];
         for (const className of classList) {
             count(fixture, className);
         }

--- a/components/src/core/drawer/drawer.component.ts
+++ b/components/src/core/drawer/drawer.component.ts
@@ -28,7 +28,7 @@ import { Subscription } from 'rxjs';
     `,
     styleUrls: ['./drawer.component.scss'],
     host: {
-        class: 'pxb-drawer'
+        class: 'pxb-drawer',
     },
 })
 export class DrawerComponent extends StateListener implements OnInit, OnChanges {

--- a/components/src/core/drawer/drawer.component.ts
+++ b/components/src/core/drawer/drawer.component.ts
@@ -16,7 +16,7 @@ import { Subscription } from 'rxjs';
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     template: `
-        <div class="pxb-drawer" [class.collapse]="!isOpen()" [class.temp-variant]="isTemporaryVariant()">
+        <div class="pxb-drawer-content" [class.collapse]="!isOpen()" [class.temp-variant]="isTemporaryVariant()">
             <!-- Drawer is responsible for managing the styles between the 4 subsections -->
             <ng-content select="pxb-drawer-header"></ng-content>
             <div class="pxb-drawer-hover-area" (mouseenter)="hoverDrawer()" (mouseleave)="unhoverDrawer()">
@@ -27,6 +27,9 @@ import { Subscription } from 'rxjs';
         </div>
     `,
     styleUrls: ['./drawer.component.scss'],
+    host: {
+        class: 'pxb-drawer'
+    },
 })
 export class DrawerComponent extends StateListener implements OnInit, OnChanges {
     @Input() open: boolean;

--- a/components/src/core/dropdown-toolbar/dropdown-toolbar.component.scss
+++ b/components/src/core/dropdown-toolbar/dropdown-toolbar.component.scss
@@ -1,4 +1,4 @@
-[dir='rtl'] .pxb-dropdown-toolbar {
+[dir='rtl'] .pxb-dropdown-toolbar-content {
     .pxb-dropdown-toolbar-icon-wrapper {
         margin-right: -8px;
         margin-left: 16px;
@@ -9,6 +9,10 @@
 }
 
 .pxb-dropdown-toolbar {
+    display: flex;
+}
+
+.pxb-dropdown-toolbar-content {
     .pxb-dropdown-toolbar-icon-wrapper > * {
         margin-right: 24px;
         margin-left: -8px;

--- a/components/src/core/dropdown-toolbar/dropdown-toolbar.component.spec.ts
+++ b/components/src/core/dropdown-toolbar/dropdown-toolbar.component.spec.ts
@@ -81,7 +81,7 @@ describe('DropdownToolbarComponent', () => {
 
         // Non-overlay classes
         const classList = [
-            '.pxb-dropdown-toolbar',
+            '.pxb-dropdown-toolbar-content',
             '.pxb-dropdown-toolbar-icon-wrapper',
             '.pxb-dropdown-toolbar-title',
             '.pxb-dropdown-toolbar-subtitle',

--- a/components/src/core/dropdown-toolbar/dropdown-toolbar.component.ts
+++ b/components/src/core/dropdown-toolbar/dropdown-toolbar.component.ts
@@ -29,7 +29,7 @@ import { MatMenuTrigger } from '@angular/material/menu';
     `,
     styleUrls: ['./dropdown-toolbar.component.scss'],
     host: {
-        class: 'pxb-dropdown-toolbar'
+        class: 'pxb-dropdown-toolbar',
     },
 })
 export class DropdownToolbarComponent {

--- a/components/src/core/dropdown-toolbar/dropdown-toolbar.component.ts
+++ b/components/src/core/dropdown-toolbar/dropdown-toolbar.component.ts
@@ -5,7 +5,7 @@ import { MatMenuTrigger } from '@angular/material/menu';
     selector: 'pxb-dropdown-toolbar',
     encapsulation: ViewEncapsulation.None,
     template: `
-        <mat-toolbar fxLayout="row" class="pxb-dropdown-toolbar">
+        <mat-toolbar fxLayout="row" class="pxb-dropdown-toolbar-content">
             <div class="pxb-dropdown-toolbar-icon-wrapper">
                 <ng-content select="[pxb-nav-icon]"></ng-content>
             </div>
@@ -28,6 +28,9 @@ import { MatMenuTrigger } from '@angular/material/menu';
         </mat-toolbar>
     `,
     styleUrls: ['./dropdown-toolbar.component.scss'],
+    host: {
+        class: 'pxb-dropdown-toolbar'
+    },
 })
 export class DropdownToolbarComponent {
     @Input() title: string;

--- a/components/src/core/empty-state/empty-state.component.html
+++ b/components/src/core/empty-state/empty-state.component.html
@@ -1,4 +1,4 @@
-<div class="pxb-empty-state">
+<div class="pxb-empty-state-content">
     <div class="pxb-empty-state-empty-icon-wrapper" #emptyIcon>
         <ng-content select="[pxb-empty-icon]"></ng-content>
     </div>

--- a/components/src/core/empty-state/empty-state.component.scss
+++ b/components/src/core/empty-state/empty-state.component.scss
@@ -1,4 +1,8 @@
 .pxb-empty-state {
+    display: flex;
+}
+
+.pxb-empty-state-content {
     height: 100%;
     width: 100%;
     display: flex;

--- a/components/src/core/empty-state/empty-state.component.spec.ts
+++ b/components/src/core/empty-state/empty-state.component.spec.ts
@@ -115,7 +115,7 @@ describe('Empty State Component', () => {
         component.description = 'description';
         fixture.detectChanges();
         const classList = [
-            '.pxb-empty-state',
+            '.pxb-empty-state-content',
             '.pxb-empty-state-empty-icon-wrapper',
             '.pxb-empty-state-title',
             '.pxb-empty-state-description',

--- a/components/src/core/empty-state/empty-state.component.ts
+++ b/components/src/core/empty-state/empty-state.component.ts
@@ -16,6 +16,9 @@ import { requireContent, requireInput } from '../../utils/utils';
     styleUrls: ['./empty-state.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
+    host: {
+        class: 'pxb-empty-state'
+    },
 })
 export class EmptyStateComponent implements OnChanges, AfterViewInit {
     @Input() title: string;

--- a/components/src/core/empty-state/empty-state.component.ts
+++ b/components/src/core/empty-state/empty-state.component.ts
@@ -17,7 +17,7 @@ import { requireContent, requireInput } from '../../utils/utils';
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     host: {
-        class: 'pxb-empty-state'
+        class: 'pxb-empty-state',
     },
 })
 export class EmptyStateComponent implements OnChanges, AfterViewInit {

--- a/components/src/core/hero/hero-banner.component.scss
+++ b/components/src/core/hero/hero-banner.component.scss
@@ -1,8 +1,8 @@
-.pxb-hero-banner-root {
+.pxb-hero-banner {
     display: flex;
 }
 
-.pxb-hero-banner {
+.pxb-hero-banner-content {
     display: flex;
     flex: 1 1 0;
     align-items: center;

--- a/components/src/core/hero/hero-banner.component.spec.ts
+++ b/components/src/core/hero/hero-banner.component.spec.ts
@@ -59,7 +59,7 @@ describe('HeroBannerComponent', () => {
     it('should enforce class naming conventions', () => {
         component.divider = true;
         fixture.detectChanges();
-        const classList = ['.pxb-hero-banner', '.pxb-hero-banner-divider'];
+        const classList = ['.pxb-hero-banner-content', '.pxb-hero-banner-divider'];
         for (const className of classList) {
             count(fixture, className);
         }

--- a/components/src/core/hero/hero-banner.component.ts
+++ b/components/src/core/hero/hero-banner.component.ts
@@ -5,14 +5,14 @@ import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@a
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     template: `
-        <div class="pxb-hero-banner">
+        <div class="pxb-hero-banner-content">
             <ng-content select="pxb-hero"></ng-content>
         </div>
         <mat-divider class="pxb-hero-banner-divider" *ngIf="divider"></mat-divider>
     `,
     styleUrls: ['./hero-banner.component.scss'],
     host: {
-        class: 'pxb-hero-banner-root', // TODO: Follow ng mat naming conventions
+        class: 'pxb-hero-banner',
     },
 })
 export class HeroBannerComponent {

--- a/components/src/core/hero/hero.component.scss
+++ b/components/src/core/hero/hero.component.scss
@@ -1,12 +1,16 @@
+.pxb-hero {
+    display: flex;
+}
+
 /* RTL */
-[dir='rtl'] .pxb-hero {
+[dir='rtl'] .pxb-hero-content {
     .pxb-hero-primary-wrapper {
         display: flex;
         justify-content: flex-end;
     }
 }
 
-.pxb-hero {
+.pxb-hero-content {
     display: flex;
     flex: 1 1 0px;
     flex-direction: column;

--- a/components/src/core/hero/hero.component.spec.ts
+++ b/components/src/core/hero/hero.component.spec.ts
@@ -96,7 +96,7 @@ describe('HeroComponent', () => {
 
     it('should enforce class naming conventions', () => {
         const classList = [
-            '.pxb-hero',
+            '.pxb-hero-content',
             '.pxb-hero-primary-wrapper',
             '.pxb-hero-channel-value-wrapper',
             '.pxb-hero-label',

--- a/components/src/core/hero/hero.component.ts
+++ b/components/src/core/hero/hero.component.ts
@@ -41,7 +41,7 @@ import { requireInput } from '../../utils/utils';
         </div>
     `,
     host: {
-        class: 'pxb-hero'
+        class: 'pxb-hero',
     },
 })
 export class HeroComponent implements OnChanges, AfterViewInit, AfterContentChecked {

--- a/components/src/core/hero/hero.component.ts
+++ b/components/src/core/hero/hero.component.ts
@@ -18,7 +18,7 @@ import { requireInput } from '../../utils/utils';
     encapsulation: ViewEncapsulation.None,
     styleUrls: ['./hero.component.scss'],
     template: `
-        <div class="pxb-hero">
+        <div class="pxb-hero-content">
             <div
                 class="pxb-hero-primary-wrapper"
                 #primaryContainer
@@ -40,6 +40,9 @@ import { requireInput } from '../../utils/utils';
             <h5 class="pxb-hero-label">{{ label }}</h5>
         </div>
     `,
+    host: {
+        class: 'pxb-hero'
+    },
 })
 export class HeroComponent implements OnChanges, AfterViewInit, AfterContentChecked {
     @Input() color: string;

--- a/components/src/core/info-list-item/info-list-item.component.scss
+++ b/components/src/core/info-list-item/info-list-item.component.scss
@@ -5,10 +5,15 @@ $contentPaddingLeft: 16px;
 $normalHeight: 72px;
 $denseHeight: 52px;
 
+.pxb-info-list-item {
+    display: flex;
+    width: 100%;
+}
+
 /* RTL */
 [dir='rtl'] {
-    .pxb-info-list-item,
-    .mat-list-base .mat-list-item.pxb-info-list-item {
+    .pxb-info-list-item-content,
+    .mat-list-base .mat-list-item.pxb-info-list-item-content {
         &.pxb-info-list-item-status .mat-list-item-content {
             border-right: solid $statusWidth;
             border-right-color: inherit;
@@ -44,8 +49,8 @@ $denseHeight: 52px;
     }
 }
 
-.pxb-info-list-item,
-.mat-list-base .mat-list-item.pxb-info-list-item {
+.pxb-info-list-item-content,
+.mat-list-base .mat-list-item.pxb-info-list-item-content {
     width: 100%;
     height: inherit; /* Used to override height applied when wrapped in a mat-list. */
     .mat-list-item-content {

--- a/components/src/core/info-list-item/info-list-item.component.spec.ts
+++ b/components/src/core/info-list-item/info-list-item.component.spec.ts
@@ -149,7 +149,7 @@ describe('InfoListItemComponent', () => {
         component.hidePadding = true;
         fixture.detectChanges();
         const classList = [
-            '.pxb-info-list-item',
+            '.pxb-info-list-item-content',
             '.pxb-info-list-item-icon-wrapper',
             '.pxb-info-list-item-left-content-wrapper',
             '.pxb-info-list-item-title-wrapper',

--- a/components/src/core/info-list-item/info-list-item.component.ts
+++ b/components/src/core/info-list-item/info-list-item.component.ts
@@ -15,7 +15,7 @@ import { isEmptyView, requireContent } from '../../utils/utils';
     encapsulation: ViewEncapsulation.None,
     template: `
         <mat-list-item
-            class="pxb-info-list-item"
+            class="pxb-info-list-item-content"
             [class.pxb-info-list-item-wrap]="wrapSubtitle || wrapTitle"
             [class.pxb-info-list-item-dense]="dense"
             [class.pxb-info-list-item-status]="statusColor"
@@ -74,6 +74,9 @@ import { isEmptyView, requireContent } from '../../utils/utils';
         </mat-divider>
     `,
     styleUrls: ['./info-list-item.component.scss'],
+    host: {
+        class: 'pxb-info-list-item'
+    },
 })
 export class InfoListItemComponent implements AfterViewInit {
     @Input() statusColor: string;

--- a/components/src/core/info-list-item/info-list-item.component.ts
+++ b/components/src/core/info-list-item/info-list-item.component.ts
@@ -75,7 +75,7 @@ import { isEmptyView, requireContent } from '../../utils/utils';
     `,
     styleUrls: ['./info-list-item.component.scss'],
     host: {
-        class: 'pxb-info-list-item'
+        class: 'pxb-info-list-item',
     },
 })
 export class InfoListItemComponent implements AfterViewInit {

--- a/components/src/core/list-item-tag/list-item-tag.component.html
+++ b/components/src/core/list-item-tag/list-item-tag.component.html
@@ -1,4 +1,4 @@
-<div class="pxb-list-item-tag" [style.backgroundColor]="backgroundColor">
+<div class="pxb-list-item-tag-content" [style.backgroundColor]="backgroundColor">
     <div class="mat-small pxb-list-item-tag-label" [style.color]="fontColor">
         {{ label }}
     </div>

--- a/components/src/core/list-item-tag/list-item-tag.component.scss
+++ b/components/src/core/list-item-tag/list-item-tag.component.scss
@@ -1,8 +1,15 @@
 .pxb-list-item-tag {
+    display: flex;
+}
+
+.pxb-list-item-tag, .pxb-list-item-tag-content {
+    border-radius: 2px;
+}
+
+.pxb-list-item-tag-content {
+    padding: 0 4px;
     overflow: hidden;
     line-height: inherit;
-    padding: 0 4px;
-    border-radius: 2px;
     letter-spacing: 1px;
 
     .pxb-list-item-tag-label {

--- a/components/src/core/list-item-tag/list-item-tag.component.scss
+++ b/components/src/core/list-item-tag/list-item-tag.component.scss
@@ -2,7 +2,8 @@
     display: flex;
 }
 
-.pxb-list-item-tag, .pxb-list-item-tag-content {
+.pxb-list-item-tag,
+.pxb-list-item-tag-content {
     border-radius: 2px;
 }
 

--- a/components/src/core/list-item-tag/list-item-tag.component.spec.ts
+++ b/components/src/core/list-item-tag/list-item-tag.component.spec.ts
@@ -30,7 +30,7 @@ describe('ListItemTagComponent', () => {
 
     it('should enforce class naming conventions', () => {
         fixture.detectChanges();
-        const classList = ['.pxb-list-item-tag', '.pxb-list-item-tag-label'];
+        const classList = ['.pxb-list-item-tag-content', '.pxb-list-item-tag-label'];
         for (const className of classList) {
             count(fixture, className);
         }

--- a/components/src/core/list-item-tag/list-item-tag.component.ts
+++ b/components/src/core/list-item-tag/list-item-tag.component.ts
@@ -7,6 +7,9 @@ import { requireInput } from '../../utils/utils';
     styleUrls: ['./list-item-tag.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
+    host: {
+        class: 'pxb-list-item-tag'
+    },
 })
 export class ListItemTagComponent implements OnChanges {
     @Input() backgroundColor: string;

--- a/components/src/core/list-item-tag/list-item-tag.component.ts
+++ b/components/src/core/list-item-tag/list-item-tag.component.ts
@@ -8,7 +8,7 @@ import { requireInput } from '../../utils/utils';
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     host: {
-        class: 'pxb-list-item-tag'
+        class: 'pxb-list-item-tag',
     },
 })
 export class ListItemTagComponent implements OnChanges {

--- a/components/src/core/score-card/score-card.component.scss
+++ b/components/src/core/score-card/score-card.component.scss
@@ -1,4 +1,11 @@
-.pxb-score-card.mat-card {
+.pxb-score-card {
+    display: flex;
+}
+
+.pxb-score-card-content.mat-card {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
     padding: 0;
 }
 

--- a/components/src/core/score-card/score-card.component.spec.ts
+++ b/components/src/core/score-card/score-card.component.spec.ts
@@ -94,7 +94,7 @@ describe('ScoreCardComponent', () => {
 
     it('should enforce class naming conventions', () => {
         const classList = [
-            '.pxb-score-card',
+            '.pxb-score-card-content',
             '.pxb-score-card-header',
             '.pxb-score-card-header-background',
             '.pxb-score-card-header-wrapper',

--- a/components/src/core/score-card/score-card.component.ts
+++ b/components/src/core/score-card/score-card.component.ts
@@ -36,7 +36,7 @@ import { requireInput } from '../../utils/utils';
     `,
     styleUrls: ['./score-card.component.scss'],
     host: {
-        class: 'pxb-score-card'
+        class: 'pxb-score-card',
     },
 })
 export class ScoreCardComponent {

--- a/components/src/core/score-card/score-card.component.ts
+++ b/components/src/core/score-card/score-card.component.ts
@@ -6,7 +6,7 @@ import { requireInput } from '../../utils/utils';
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     template: `
-        <mat-card class="pxb-score-card">
+        <mat-card class="pxb-score-card-content">
             <div class="pxb-score-card-header">
                 <div class="pxb-score-card-header-background"></div>
                 <div class="pxb-score-card-header-wrapper">
@@ -35,6 +35,9 @@ import { requireInput } from '../../utils/utils';
         </mat-card>
     `,
     styleUrls: ['./score-card.component.scss'],
+    host: {
+        class: 'pxb-score-card'
+    },
 })
 export class ScoreCardComponent {
     @Input() headerTitle: string;

--- a/components/src/core/user-menu/user-menu-avatar.component.ts
+++ b/components/src/core/user-menu/user-menu-avatar.component.ts
@@ -12,7 +12,7 @@ import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@a
         </div>
     `,
     host: {
-        class: 'pxb-user-menu-avatar'
+        class: 'pxb-user-menu-avatar',
     },
 })
 export class UserMenuAvatarComponent {

--- a/components/src/core/user-menu/user-menu-avatar.component.ts
+++ b/components/src/core/user-menu/user-menu-avatar.component.ts
@@ -5,12 +5,15 @@ import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@a
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     template: `
-        <div class="pxb-user-menu-avatar">
+        <div class="pxb-user-menu-avatar-content">
             <div *ngIf="avatarValue" class="mat-h2 pxb-user-menu-text-avatar">{{ avatarValue }}</div>
             <img *ngIf="avatarImage" [src]="avatarImage" alt="User Menu Avatar" />
             <ng-content></ng-content>
         </div>
     `,
+    host: {
+        class: 'pxb-user-menu-avatar'
+    },
 })
 export class UserMenuAvatarComponent {
     @Input() avatarValue: string;

--- a/components/src/core/user-menu/user-menu.component.scss
+++ b/components/src/core/user-menu/user-menu.component.scss
@@ -10,12 +10,15 @@ $size: 40px;
 }
 
 .pxb-user-menu-avatar {
+    display: flex;
+    border-radius: 50%;
+}
+.pxb-user-menu-avatar-content {
     height: $size;
     width: $size;
     line-height: $size;
     cursor: pointer;
     text-align: center;
-    border-radius: 50%;
     display: flex;
     justify-content: center;
     align-content: center;

--- a/components/src/core/user-menu/user-menu.component.ts
+++ b/components/src/core/user-menu/user-menu.component.ts
@@ -63,6 +63,9 @@ import { animate, state, style, transition, trigger } from '@angular/animations'
             </mat-card>
         </ng-template>
     `,
+    host: {
+        class: 'pxb-user-menu'
+    },
 })
 export class UserMenuComponent {
     @Input() avatarValue: string;

--- a/components/src/core/user-menu/user-menu.component.ts
+++ b/components/src/core/user-menu/user-menu.component.ts
@@ -64,7 +64,7 @@ import { animate, state, style, transition, trigger } from '@angular/animations'
         </ng-template>
     `,
     host: {
-        class: 'pxb-user-menu'
+        class: 'pxb-user-menu',
     },
 })
 export class UserMenuComponent {

--- a/docs/ChannelValue.md
+++ b/docs/ChannelValue.md
@@ -58,7 +58,8 @@ Each PX Blue component has classes which can be used to override component style
 
 | Name                           | Description                          |
 | ------------------------------ | ------------------------------------ |
-| pxb-channel-value              | Styles applied to the root element   |
+| pxb-channel-value              | Styles applied to the tag            |
+| pxb-channel-value-content      | Styles applied to the root element   |
 | pxb-channel-value-icon-wrapper | Styles applied to the icon container |
 | pxb-channel-value-units        | Styles applied to the units @Input   |
 | pxb-channel-value-value        | Styles applied to the value @Input   |

--- a/docs/Drawer.md
+++ b/docs/Drawer.md
@@ -50,7 +50,8 @@ Each PX Blue component has classes which can be used to override component style
 
 | Name                  | Description                                  |
 | --------------------- | -------------------------------------------- |
-| pxb-drawer            | Styles applied to the root element           |
+| pxb-drawer            | Styles applied to the tag                    |
+| pxb-drawer-content    | Styles applied to the root element           |
 | pxb-drawer-hover-area | Hoverable area that temporarily opens drawer |
 
 </div>
@@ -108,7 +109,8 @@ Each PX Blue component has classes which can be used to override component style
 
 | Name                          | Description                             |
 | ----------------------------- | --------------------------------------- |
-| pxb-drawer-layout             | Styles applied to the root element      |
+| pxb-drawer-layout             | Styles applied to the tag               |
+| pxb-drawer-layout-content     | Styles applied to the root element      |
 | pxb-drawer-layout-sidenav     | Styles applied to mat-sidenav-container |
 | pxb-drawer-layout-nav-content | Styles applied to mat-sidenav-content   |
 

--- a/docs/DropdownToolbar.md
+++ b/docs/DropdownToolbar.md
@@ -60,10 +60,11 @@ Each PX Blue component has classes which can be used to override component style
 
 | Name                                         | Description                            |
 | -------------------------------------------- | -------------------------------------- |
-| pxb-dropdown-toolbar                        | Styles applied to the root element     |
-| pxb-dropdown-toolbar-icon-wrapper           | Styles applied to the left icon        |
-| pxb-dropdown-toolbar-text-content-container | Styles applied to the text content     |
-| pxb-dropdown-toolbar-title                  | Styles applied to the title            |
-| pxb-dropdown-toolbar-subtitle-container     | Styles applied to the subtitle wrapper |
-| pxb-dropdown-toolbar-subtitle               | Styles applied to the subtitle         |
-| pxb-dropdown-toolbar-menu-wrapper           | Styles applied to the menu             |
+| pxb-dropdown-toolbar                         | Styles applied to the tag              |
+| pxb-dropdown-toolbar-content                 | Styles applied to the root element     |
+| pxb-dropdown-toolbar-icon-wrapper            | Styles applied to the left icon        |
+| pxb-dropdown-toolbar-text-content-container  | Styles applied to the text content     |
+| pxb-dropdown-toolbar-title                   | Styles applied to the title            |
+| pxb-dropdown-toolbar-subtitle-container      | Styles applied to the subtitle wrapper |
+| pxb-dropdown-toolbar-subtitle                | Styles applied to the subtitle         |
+| pxb-dropdown-toolbar-menu-wrapper            | Styles applied to the menu             |

--- a/docs/EmptyState.md
+++ b/docs/EmptyState.md
@@ -66,7 +66,8 @@ Each PX Blue component has classes which can be used to override component style
 
 | Name                               | Description                              |
 | ---------------------------------- | ---------------------------------------- |
-| pxb-empty-state                    | Styles applied to the root element       |
+| pxb-empty-state                    | Styles applied to the tag                |
+| pxb-empty-state-content            | Styles applied to the root element       |
 | pxb-empty-state-empty-icon-wrapper | Styles applied to the icon container     |
 | pxb-empty-state-title              | Styles applied to the title @Input       |
 | pxb-empty-state-description        | Styles applied to the description @Input |

--- a/docs/Hero.md
+++ b/docs/Hero.md
@@ -76,7 +76,8 @@ Each PX Blue component has classes which can be used to override component style
 
 | Name                           | Description                                  |
 | ------------------------------ | -------------------------------------------- |
-| pxb-hero                       | Styles applied to the root element           |
+| pxb-hero                       | Styles applied to the tag                    |
+| pxb-hero-content               | Styles applied to the root element           |
 | pxb-hero-primary-wrapper       | Styles applied to the primary icon container |
 | pxb-hero-channel-value-wrapper | Styles applied to channel-value              |
 | pxb-hero-label                 | Styles applied to label @Input               |

--- a/docs/InfoListItem.md
+++ b/docs/InfoListItem.md
@@ -64,7 +64,8 @@ Each PX Blue component has classes which can be used to override component style
 
 | Name                                     | Description                                  |
 | ---------------------------------------- | -------------------------------------------- |
-| pxb-info-list-item                       | Styles applied to the root element           |
+| pxb-info-list-item                       | Styles applied to the tag                    |
+| pxb-info-list-item-content               | Styles applied to the root element           |
 | pxb-info-list-item-icon-wrapper          | Styles applied to the icon container         |
 | pxb-info-list-item-info-wrapper          | Styles applied to the info container         |
 | pxb-info-list-item-left-content-wrapper  | Styles applied to the leftContent container  |

--- a/docs/ListItemTag.md
+++ b/docs/ListItemTag.md
@@ -39,7 +39,8 @@ Parent element (`pxb-list-item-tag`) attributes:
 
 Each PX Blue component has classes which can be used to override component styles:
 
-| Name                    | Description                        |
-| ----------------------- | ---------------------------------- |
-| pxb-list-item-tag       | Styles applied to the root element |
-| pxb-list-item-tag-label | Styles applied to the label @Input |
+| Name                      | Description                        |
+| ------------------------- | ---------------------------------- |
+| pxb-list-item-tag         | Styles applied to the tag          |
+| pxb-list-item-tag-content | Styles applied to the root element |
+| pxb-list-item-tag-label   | Styles applied to the label @Input |

--- a/docs/ScoreCard.md
+++ b/docs/ScoreCard.md
@@ -88,7 +88,8 @@ Each PX Blue component has classes which can be used to override component style
 
 | Name                                | Description                                       |
 | ----------------------------------- | ------------------------------------------------- |
-| pxb-score-card                      | Styles applied to the root element                |
+| pxb-score-card                      | Styles applied to the tag                         |
+| pxb-score-card-content              | Styles applied to the root element                |
 | pxb-score-card-header               | Styles applied to the scorecard header            |
 | pxb-score-card-header-background    | Hidden overlay used to provide a background image |
 | pxb-score-card-header-wrapper       | Styles used to align header text and actions      |


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #112, Fixes #111 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Top-level components have a class applied to the host element
-  Docs updated

UserMenu has no root-class, so it has no `pxb-user-menu-content` class.

These components are internal to the Drawer; I didn't apply a `display: flex` to them since they work fine already and shouldn't be used outside of the Drawer. 
- DrawerHeader
- DrawerSubheader
- DrawerBody
- DrawerNavItem
- DrawerNavGroup
- DrawerFooter
