### PR TITLE
Add height and width specs to the pxb-drawer-layout-content wrapper

### DIFF
--- a/components/src/core/drawer/drawer-layout/drawer-layout.component.scss
+++ b/components/src/core/drawer/drawer-layout/drawer-layout.component.scss
@@ -5,6 +5,11 @@ $transition: 300ms cubic-bezier(0.4, 0, 0.2, 1);
     border-left: 0; // Border-left is provided by the Drawer component.
 }
 
+.pxb-drawer-layout-content {
+    height: 100%;
+    width: 100%;
+}
+
 .pxb-drawer-layout {
     height: 100%;
     width: 100%;


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Add styles to specify height/width

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
This fix removes the gray area as seen here:
![image](https://user-images.githubusercontent.com/6538289/92791335-946db980-f37a-11ea-9ddd-8d44132950b2.png)
