### PR TITLE
Add font-size to info-list-item subtitle and info wrappers

### DIFF
--- a/components/src/core/info-list-item/info-list-item.component.scss
+++ b/components/src/core/info-list-item/info-list-item.component.scss
@@ -95,13 +95,16 @@ $denseHeight: 52px;
         margin-bottom: 0;
     }
 
-    .pxb-info-list-item-subtitle-wrapper {
+    .pxb-info-list-item-subtitle-wrapper,
+    .pxb-info-list-item-info-wrapper {
         font-weight: 400;
         line-height: 1.3;
+        font-size: 14px;
     }
 
     .pxb-info-list-item-title-wrapper,
-    .pxb-info-list-item-subtitle-wrapper {
+    .pxb-info-list-item-subtitle-wrapper,
+    .pxb-info-list-item-info-wrapper {
         * {
             white-space: nowrap;
             overflow: hidden;


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes PXBLUE-1537.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Add font-size to info-list-item subtitle and info wrappers

Notes: This update is being made so that the angular-deign-pattern repo has the appropriate font-sizes for subtitle and info content.

Follow up tasks:
- publish new @pxblue/angular-components beta package
- update angular-design-pattern repo with latest @pxblue/angular-components beta package
