### PR TITLE
Bug/browser animations module

### DIFF
--- a/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.spec.ts
+++ b/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.spec.ts
@@ -3,6 +3,7 @@ import { DrawerNavItemComponent } from './drawer-nav-item.component';
 import { DrawerNavItemModule } from './drawer-nav-item.module';
 import { Component } from '@angular/core';
 import { count } from 'src/utils/test-utils';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 @Component({
     template: `
@@ -18,7 +19,7 @@ describe('DrawerNavItemComponent', () => {
     beforeEach(() => {
         void TestBed.configureTestingModule({
             declarations: [TestDrawerNavItem],
-            imports: [DrawerNavItemModule],
+            imports: [DrawerNavItemModule, BrowserAnimationsModule],
         }).compileComponents();
         fixture = TestBed.createComponent(DrawerNavItemComponent);
         component = fixture.componentInstance;

--- a/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.module.ts
+++ b/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.module.ts
@@ -6,7 +6,6 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatRippleModule } from '@angular/material/core';
 import { MatExpansionModule } from '@angular/material/expansion';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MatTooltipModule } from '@angular/material/tooltip';
 
 @NgModule({
@@ -19,7 +18,6 @@ import { MatTooltipModule } from '@angular/material/tooltip';
         MatDividerModule,
         MatRippleModule,
         MatExpansionModule,
-        BrowserAnimationsModule,
     ],
     exports: [DrawerNavItemComponent],
 })

--- a/components/src/core/dropdown-toolbar/dropdown-toolbar.component.spec.ts
+++ b/components/src/core/dropdown-toolbar/dropdown-toolbar.component.spec.ts
@@ -5,6 +5,7 @@ import { DropdownToolbarModule } from './dropdown-toolbar.module';
 import { Component } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { count } from '../../utils/test-utils';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 @Component({
     template: `
@@ -25,7 +26,7 @@ describe('DropdownToolbarComponent', () => {
     beforeEach(() => {
         void TestBed.configureTestingModule({
             declarations: [TestDropdownToolbar],
-            imports: [DropdownToolbarModule, MatIconModule],
+            imports: [DropdownToolbarModule, MatIconModule, BrowserAnimationsModule],
         }).compileComponents();
         fixture = TestBed.createComponent(DropdownToolbarComponent);
         component = fixture.componentInstance;

--- a/components/src/core/dropdown-toolbar/dropdown-toolbar.module.ts
+++ b/components/src/core/dropdown-toolbar/dropdown-toolbar.module.ts
@@ -7,13 +7,11 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
 import { SpacerModule } from '../utility/public-api';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 @NgModule({
     declarations: [DropdownToolbarComponent],
     imports: [
         CommonModule,
-        BrowserAnimationsModule,
         MatToolbarModule,
         MatSelectModule,
         MatFormFieldModule,

--- a/components/src/core/user-menu/user-menu.component.spec.ts
+++ b/components/src/core/user-menu/user-menu.component.spec.ts
@@ -4,6 +4,7 @@ import { UserMenuComponent } from './user-menu.component';
 import { Component } from '@angular/core';
 import { MatListModule } from '@angular/material/list';
 import { count } from '../../utils/test-utils';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 /** Test component that contains an MatButton. */
 @Component({
@@ -38,7 +39,7 @@ describe('UserMenuComponent', () => {
     beforeEach(() => {
         void TestBed.configureTestingModule({
             declarations: [UserMenuNavItemsTest, UserMenuCustomHeaderTest],
-            imports: [UserMenuModule, MatListModule],
+            imports: [UserMenuModule, MatListModule, BrowserAnimationsModule],
         }).compileComponents();
         fixture = TestBed.createComponent(UserMenuComponent);
         component = fixture.componentInstance;

--- a/components/src/core/user-menu/user-menu.module.ts
+++ b/components/src/core/user-menu/user-menu.module.ts
@@ -9,13 +9,7 @@ import { MatCardModule } from '@angular/material/card';
 
 @NgModule({
     declarations: [UserMenuComponent, UserMenuAvatarComponent],
-    imports: [
-        CommonModule,
-        MatCardModule,
-        InfoListItemModule,
-        OverlayModule,
-        DrawerHeaderModule,
-    ],
+    imports: [CommonModule, MatCardModule, InfoListItemModule, OverlayModule, DrawerHeaderModule],
     exports: [UserMenuComponent, UserMenuAvatarComponent],
 })
 export class UserMenuModule {}

--- a/components/src/core/user-menu/user-menu.module.ts
+++ b/components/src/core/user-menu/user-menu.module.ts
@@ -6,13 +6,11 @@ import { InfoListItemModule } from '../info-list-item/info-list-item.module';
 import { UserMenuAvatarComponent } from './user-menu-avatar.component';
 import { DrawerHeaderModule } from '../drawer/drawer-header/drawer-header.module';
 import { MatCardModule } from '@angular/material/card';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 @NgModule({
     declarations: [UserMenuComponent, UserMenuAvatarComponent],
     imports: [
         CommonModule,
-        BrowserAnimationsModule,
         MatCardModule,
         InfoListItemModule,
         OverlayModule,

--- a/demos/storybook/stories/dropdown-toolbar/_module.stories.ts
+++ b/demos/storybook/stories/dropdown-toolbar/_module.stories.ts
@@ -12,6 +12,7 @@ import { withBasicUsage } from './with-basic-usage.stories';
 import { withNavIcon } from './with-nav-icon.stories';
 import { withCustomMenu } from './with-custom-menu.stories';
 import { MatListModule } from '@angular/material/list';
+import {BrowserAnimationsModule} from "@angular/platform-browser/animations";
 
 export const dropdownToolbarWrapper = () => (storyFn: any): any => {
     const story = storyFn();
@@ -33,6 +34,7 @@ storiesOf(`${COMPONENT_SECTION_NAME}/Dropdown Toolbar`, module)
     .addDecorator(
         moduleMetadata({
             imports: [
+                BrowserAnimationsModule,
                 DropdownToolbarModule,
                 UtilModule,
                 MatIconModule,

--- a/demos/storybook/stories/dropdown-toolbar/_module.stories.ts
+++ b/demos/storybook/stories/dropdown-toolbar/_module.stories.ts
@@ -12,7 +12,7 @@ import { withBasicUsage } from './with-basic-usage.stories';
 import { withNavIcon } from './with-nav-icon.stories';
 import { withCustomMenu } from './with-custom-menu.stories';
 import { MatListModule } from '@angular/material/list';
-import {BrowserAnimationsModule} from "@angular/platform-browser/animations";
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 export const dropdownToolbarWrapper = () => (storyFn: any): any => {
     const story = storyFn();

--- a/demos/storybook/stories/user-menu/_module.stories.ts
+++ b/demos/storybook/stories/user-menu/_module.stories.ts
@@ -22,7 +22,7 @@ import { withinToolbar } from './within-a-toolbar.stories';
 import { withFullConfig } from './with-full-config.stories';
 import { withCustomMenu } from './with-custom-menu.stories';
 import { withMenuPlacement } from './with-menu-placement-options.stories';
-import {BrowserAnimationsModule} from "@angular/platform-browser/animations";
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 export const withinToolbarWrapper = () => (storyFn: any): any => {
     const story = storyFn();

--- a/demos/storybook/stories/user-menu/_module.stories.ts
+++ b/demos/storybook/stories/user-menu/_module.stories.ts
@@ -22,6 +22,7 @@ import { withinToolbar } from './within-a-toolbar.stories';
 import { withFullConfig } from './with-full-config.stories';
 import { withCustomMenu } from './with-custom-menu.stories';
 import { withMenuPlacement } from './with-menu-placement-options.stories';
+import {BrowserAnimationsModule} from "@angular/platform-browser/animations";
 
 export const withinToolbarWrapper = () => (storyFn: any): any => {
     const story = storyFn();
@@ -42,6 +43,7 @@ storiesOf(`${COMPONENT_SECTION_NAME}/User Menu`, module)
     .addDecorator(
         moduleMetadata({
             imports: [
+                BrowserAnimationsModule,
                 MatToolbarModule,
                 UserMenuModule,
                 InfoListItemModule,


### PR DESCRIPTION
Nikita from project Zeus reached out to me saying that the UserMenu does not work in her project.  Upon closer inspection of the UserMenu module imports, it seems we should not be importing the BrowserAnimationModule here;  this module should only be imported once in the app, within the AppModule.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Remove BrowserAnimationModule from individual component modules.
- Add BrowserAnimationModule to storybooks that require it.  (UserMenu & DropdownToolbar)

