### PR TITLE
Add display flex to host class

### DIFF
--- a/components/src/core/user-menu/user-menu.component.scss
+++ b/components/src/core/user-menu/user-menu.component.scss
@@ -9,6 +9,10 @@ $size: 40px;
     }
 }
 
+.pxb-user-menu {
+    display: flex;
+}
+
 .pxb-user-menu-avatar {
     display: flex;
     border-radius: 50%;


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Add `display: flex` to host class on UserMenu


If the host class (or parent container) does not have display: flex specified, the default width is 100% of the container.  It'll look something like this:

![image](https://user-images.githubusercontent.com/6538289/93896508-fe615980-fcbe-11ea-8d84-d1295a25a21a.png)

Adding display: flex to the host class makes the UserMenu look normal again:
![image](https://user-images.githubusercontent.com/6538289/93896567-1042fc80-fcbf-11ea-9f4c-a891ce3632fd.png)
