### PR TITLE
Bug/list item tag display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## v3.0.1
+
+-   Fixes bug in InfoListItem where divider was working with `mat-ripple`.
+-   Changes default display setting of ListItemTag so it works in non-flex containers.
+
 ## v3.0.0
 
 -   Adds a new `rail` variant to the `<pxb-drawer-layout>`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## v3.0.1
 
--   Fixes bug in InfoListItem where divider was working with `mat-ripple`.
--   Changes default display setting of ListItemTag so it works in non-flex containers.
+-   Fixes bug in InfoListItem where divider was not working with `mat-ripple`.
+-   Changes default display setting of ListItemTag so it doesn't take up 100% width in non-flex containers.
 
 ## v3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## v3.0.1
+## v3.0.1 (Not published)
 
 -   Fixes bug in InfoListItem where divider was not working with `mat-ripple`.
 -   Changes default display setting of ListItemTag so it doesn't take up 100% width in non-flex containers.

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pxblue/angular-components",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "description": "Angular components for PX Blue applications",
     "scripts": {
         "ng": "ng",

--- a/components/src/core/list-item-tag/list-item-tag.component.scss
+++ b/components/src/core/list-item-tag/list-item-tag.component.scss
@@ -1,5 +1,5 @@
 .pxb-list-item-tag {
-    display: block;
+    display: inline-block;
 }
 
 .pxb-list-item-tag,

--- a/components/src/core/list-item-tag/list-item-tag.component.scss
+++ b/components/src/core/list-item-tag/list-item-tag.component.scss
@@ -1,5 +1,5 @@
 .pxb-list-item-tag {
-    display: flex;
+    display: block;
 }
 
 .pxb-list-item-tag,


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #176 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Change the default display settings for ListItemTag so it doesn't take up 100% width of a non-flex container.

