### PR TITLE
Bug/storybook usermenu

### DIFF
--- a/components/src/core/user-menu/user-menu.component.scss
+++ b/components/src/core/user-menu/user-menu.component.scss
@@ -1,4 +1,3 @@
-@import '~@angular/cdk/overlay-prebuilt.css';
 $size: 40px;
 
 /* RTL */

--- a/demos/storybook/stories/user-menu/_module.stories.ts
+++ b/demos/storybook/stories/user-menu/_module.stories.ts
@@ -74,6 +74,7 @@ storiesOf(`${COMPONENT_SECTION_NAME}/User Menu`, module)
     .addDecorator(
         moduleMetadata({
             imports: [
+                BrowserAnimationsModule,
                 MatToolbarModule,
                 InfoListItemModule,
                 UserMenuModule,


### PR DESCRIPTION
Changes: 
- Add BrowserAnimationModule to fix this story: https://pxblue-components.github.io/angular/?path=/story/components-user-menu--within-a-toolbar
- Remove unneeded import from UserMenu styles

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
This is what the `within a toolbar` story looks like in master when you click on the UserMenu.  This example was missing an animation module.  Must have been accidently removed at some point. 
![image](https://user-images.githubusercontent.com/6538289/95126463-8cf4c280-0724-11eb-9728-9726e662fce3.png)

