### PR TITLE
Use angular 8 showcase for angular 8 version of comp library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "demos/showcase"]
 	path = demos/showcase
 	url = https://github.com/pxblue/angular-showcase-demo
-	branch = dev
+	branch = release/angular-8-demo


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Use `release/angular-8-demo` for our angular 8 component libary
