### PR TITLE
Feature/empty state ng content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v4.0.0 (not published)
 
 -   Migrate to Angular 10
+-   Enhance `<pxb-empty-state>` to allow ng-content as `title` or `description`.
 
 ## v3.0.1
 

--- a/components/src/core/empty-state/empty-state.component.html
+++ b/components/src/core/empty-state/empty-state.component.html
@@ -2,8 +2,14 @@
     <div class="pxb-empty-state-empty-icon-wrapper" #emptyIcon>
         <ng-content select="[pxb-empty-icon]"></ng-content>
     </div>
-    <h2 class="pxb-empty-state-title">{{ title }}</h2>
-    <p *ngIf="description" class="pxb-empty-state-description mat-subheading-1">{{ description }}</p>
+    <h2 class="pxb-empty-state-title">
+        <ng-content select="[pxb-title]" *ngIf="!title"></ng-content>
+        {{ title }}
+    </h2>
+    <p class="pxb-empty-state-description mat-subheading-1">
+        <ng-content select="[pxb-description]" *ngIf="!description"></ng-content>
+        {{ description }}
+    </p>
     <div class="pxb-empty-state-actions-wrapper">
         <ng-content select="[pxb-actions]"></ng-content>
     </div>

--- a/components/src/core/empty-state/empty-state.component.spec.ts
+++ b/components/src/core/empty-state/empty-state.component.spec.ts
@@ -17,7 +17,6 @@ class EmptyStateBasicUsageComponent {
     @Input() description: string;
 }
 
-/** Test component that contains an MatButton. */
 @Component({
     selector: 'test-app',
     template: `
@@ -31,7 +30,30 @@ class EmptyStateBasicUsageComponent {
         </pxb-empty-state>
     `,
 })
-class TestEmpty {}
+class TestIconActions {}
+
+
+@Component({
+    selector: 'test-description-content',
+    template: `
+        <pxb-empty-state>
+            <span pxb-empty-icon></span>
+            <div pxb-description>description</div>
+        </pxb-empty-state>
+    `,
+})
+class TestDescriptionContent {}
+
+@Component({
+    selector: 'test-title-content',
+    template: `
+        <pxb-empty-state>
+            <span pxb-empty-icon></span>
+            <div pxb-title>title</div>
+        </pxb-empty-state>
+    `,
+})
+class TestTitleContent {}
 
 describe('Empty State Component', () => {
     let fixture: ComponentFixture<EmptyStateBasicUsageComponent>;
@@ -40,7 +62,12 @@ describe('Empty State Component', () => {
     beforeEach(async(() => {
         void TestBed.configureTestingModule({
             imports: [EmptyStateModule],
-            declarations: [EmptyStateBasicUsageComponent, TestEmpty],
+            declarations: [
+                EmptyStateBasicUsageComponent, 
+                TestIconActions, 
+                TestDescriptionContent,
+                TestTitleContent
+            ],
         }).compileComponents();
     }));
 
@@ -54,23 +81,37 @@ describe('Empty State Component', () => {
         void expect(component).toBeTruthy();
     });
 
-    it('should show title when supplied', () => {
+    it('should show title when input supplied', () => {
         component.title = 'title';
         fixture.detectChanges();
         const titleElement = fixture.debugElement.query(By.css('h2'));
         void expect(titleElement.nativeElement.innerHTML).toContain('title');
     });
 
-    it('should show description when supplied', () => {
+    it('should show title when ng-content supplied', () => {
+        const testFixture = TestBed.createComponent(TestTitleContent);
+        testFixture.detectChanges();
+        const titleElement = testFixture.debugElement.query(By.css('h2'));
+        void expect(titleElement.nativeElement.innerHTML).toContain('title');
+    });
+
+    it('should show description when input supplied', () => {
         component.description = 'description';
         fixture.detectChanges();
         const descriptionElement = fixture.debugElement.query(By.css('p'));
         void expect(descriptionElement.nativeElement.innerHTML).toContain('description');
     });
 
+    it('should show description when ng-content supplied', () => {
+        const testFixture = TestBed.createComponent(TestDescriptionContent);
+        testFixture.detectChanges();
+        const descriptionElement = testFixture.debugElement.query(By.css('p'));
+        void expect(descriptionElement.nativeElement.innerHTML).toContain('description');
+    });
+
     // Action Check
     it('should show actions when supplied', () => {
-        const actionFixture = TestBed.createComponent(TestEmpty);
+        const actionFixture = TestBed.createComponent(TestIconActions);
         let actionElement = actionFixture.debugElement.query(By.css('.withActions [pxb-actions]'));
         void expect(actionElement).not.toBeNull();
 
@@ -80,7 +121,7 @@ describe('Empty State Component', () => {
 
     // Icon Check
     it('should show icon when supplied', () => {
-        const iconFixture = TestBed.createComponent(TestEmpty);
+        const iconFixture = TestBed.createComponent(TestIconActions);
         let actionElement = iconFixture.debugElement.query(By.css('.withIcon [pxb-empty-icon]'));
         void expect(actionElement).not.toBeNull();
 

--- a/components/src/core/empty-state/empty-state.component.spec.ts
+++ b/components/src/core/empty-state/empty-state.component.spec.ts
@@ -58,36 +58,14 @@ describe('Empty State Component', () => {
         component.title = 'title';
         fixture.detectChanges();
         const titleElement = fixture.debugElement.query(By.css('h2'));
-        void expect(titleElement.nativeElement.innerHTML).toBe('title');
-    });
-
-    it('should throw a warning when the title is not supplied', () => {
-        component.title = undefined;
-        const warnSpy = spyOn(console, 'warn').and.stub();
-        fixture.detectChanges();
-        void expect(warnSpy).toHaveBeenCalledTimes(1);
-    });
-
-    it('should not show empty title', () => {
-        component.title = undefined;
-        spyOn(console, 'warn').and.stub();
-        fixture.detectChanges();
-        const titleElement = fixture.debugElement.query(By.css('h2'));
-        void expect(titleElement.nativeElement.innerHTML).toBeFalsy();
+        void expect(titleElement.nativeElement.innerHTML).toContain('title');
     });
 
     it('should show description when supplied', () => {
         component.description = 'description';
         fixture.detectChanges();
         const descriptionElement = fixture.debugElement.query(By.css('p'));
-        void expect(descriptionElement.nativeElement.innerHTML).toBe('description');
-    });
-
-    it('should not show empty description', () => {
-        component.description = '';
-        fixture.detectChanges();
-        const descriptionElement = fixture.debugElement.query(By.css('p'));
-        void expect(descriptionElement).toBeFalsy();
+        void expect(descriptionElement.nativeElement.innerHTML).toContain('description');
     });
 
     // Action Check

--- a/components/src/core/empty-state/empty-state.component.spec.ts
+++ b/components/src/core/empty-state/empty-state.component.spec.ts
@@ -32,7 +32,6 @@ class EmptyStateBasicUsageComponent {
 })
 class TestIconActions {}
 
-
 @Component({
     selector: 'test-description-content',
     template: `
@@ -62,12 +61,7 @@ describe('Empty State Component', () => {
     beforeEach(async(() => {
         void TestBed.configureTestingModule({
             imports: [EmptyStateModule],
-            declarations: [
-                EmptyStateBasicUsageComponent, 
-                TestIconActions, 
-                TestDescriptionContent,
-                TestTitleContent
-            ],
+            declarations: [EmptyStateBasicUsageComponent, TestIconActions, TestDescriptionContent, TestTitleContent],
         }).compileComponents();
     }));
 

--- a/components/src/core/empty-state/empty-state.component.ts
+++ b/components/src/core/empty-state/empty-state.component.ts
@@ -4,11 +4,10 @@ import {
     Component,
     ElementRef,
     Input,
-    OnChanges,
     ViewChild,
     ViewEncapsulation,
 } from '@angular/core';
-import { requireContent, requireInput } from '../../utils/utils';
+import { requireContent } from '../../utils/utils';
 
 @Component({
     selector: 'pxb-empty-state',

--- a/components/src/core/empty-state/empty-state.component.ts
+++ b/components/src/core/empty-state/empty-state.component.ts
@@ -20,15 +20,11 @@ import { requireContent, requireInput } from '../../utils/utils';
         class: 'pxb-empty-state',
     },
 })
-export class EmptyStateComponent implements OnChanges, AfterViewInit {
-    @Input() title: string;
+export class EmptyStateComponent implements AfterViewInit {
     @Input() description: string;
+    @Input() title: string;
 
     @ViewChild('emptyIcon') emptyIcon: ElementRef;
-
-    ngOnChanges(): void {
-        requireInput<EmptyStateComponent>(['title'], this);
-    }
 
     ngAfterViewInit(): void {
         const required = { selector: 'emptyIcon', ref: this.emptyIcon };

--- a/docs/EmptyState.md
+++ b/docs/EmptyState.md
@@ -45,7 +45,7 @@ Parent element (`<pxb-empty-state>`) attributes:
 | @Input      | Description                   | Type     | Required | Default |
 | ----------- | ----------------------------- | -------- | -------- | ------- |
 | description | The secondary text to display | `string` | no       |         |
-| title       | The main text to display      | `string` | yes      |         |
+| title       | The main text to display      | `string` | no       |         |
 
 </div>
 
@@ -57,8 +57,8 @@ The following child elements are projected into `<pxb-empty-state>`:
 | ----------------- | ------------------------------ | -------- | ------- |
 | [pxb-actions]     | action elements below the text | no       |         |
 | [pxb-empty-icon]  | The large icon to display      | yes      |         |
-| [pxb-description] | The secondary text to display  | yes      |         |
-| [pxb-title]       | The main text to display       | yes      |         |
+| [pxb-description] | The secondary text to display  | no       |         |
+| [pxb-title]       | The main text to display       | no       |         |
 
 </div>
 

--- a/docs/EmptyState.md
+++ b/docs/EmptyState.md
@@ -53,10 +53,12 @@ The following child elements are projected into `<pxb-empty-state>`:
 
 <div style="overflow: auto;">
 
-| Selector         | Description                    | Required | Default |
-| ---------------- | ------------------------------ | -------- | ------- |
-| [pxb-actions]    | action elements below the text | no       |         |
-| [pxb-empty-icon] | The large icon to display      | yes      |         |
+| Selector          | Description                    | Required | Default |
+| ----------------- | ------------------------------ | -------- | ------- |
+| [pxb-actions]     | action elements below the text | no       |         |
+| [pxb-empty-icon]  | The large icon to display      | yes      |         |
+| [pxb-description] | The secondary text to display  | yes      |         |
+| [pxb-title]       | The main text to display       | yes      |         |
 
 </div>
 


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Add ability to use ng-content for title and description in empty-state component.

Fixes #187 