### PR TITLE
Drawer Shadow and EnableSelectionHierarchy

### DIFF
--- a/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.ts
+++ b/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.ts
@@ -193,7 +193,7 @@ export class DrawerNavItemComponent extends StateListener implements Omit<Drawer
 
         this.navItemEl.nativeElement.classList.remove('pxb-drawer-nav-item-active-tree');
 
-        if (!this.drawerService.hasEnableSelectionHierarchy()) {
+        if (this.drawerService.hasDisableActiveItemParentStyles()) {
             return;
         }
 

--- a/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.ts
+++ b/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.ts
@@ -130,8 +130,6 @@ export class DrawerNavItemComponent extends StateListener implements Omit<Drawer
     @Input() subtitle: string;
     @Input() title: string;
     @Input() hidden = false;
-    //    @Input() compact = false;
-    @Input() enableSelectionHierarchy = false;
 
     @Output() select: EventEmitter<string> = new EventEmitter<string>();
 
@@ -147,7 +145,7 @@ export class DrawerNavItemComponent extends StateListener implements Omit<Drawer
     depth: number;
     id: number;
 
-    constructor(drawerService: DrawerService, changeDetectorRef: ChangeDetectorRef) {
+    constructor(public drawerService: DrawerService, changeDetectorRef: ChangeDetectorRef) {
         super(drawerService, changeDetectorRef);
         this.id = drawerService.createNavItemID();
         this.drawerService.drawerActiveItemChanges().subscribe(() => {
@@ -195,7 +193,7 @@ export class DrawerNavItemComponent extends StateListener implements Omit<Drawer
 
         this.navItemEl.nativeElement.classList.remove('pxb-drawer-nav-item-active-tree');
 
-        if (!this.enableSelectionHierarchy) {
+        if (!this.drawerService.isEnableSelectionHierarchy()) {
             return;
         }
 

--- a/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.ts
+++ b/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.ts
@@ -145,7 +145,7 @@ export class DrawerNavItemComponent extends StateListener implements Omit<Drawer
     depth: number;
     id: number;
 
-    constructor(public drawerService: DrawerService, changeDetectorRef: ChangeDetectorRef) {
+    constructor(drawerService: DrawerService, changeDetectorRef: ChangeDetectorRef) {
         super(drawerService, changeDetectorRef);
         this.id = drawerService.createNavItemID();
         this.drawerService.drawerActiveItemChanges().subscribe(() => {
@@ -193,7 +193,7 @@ export class DrawerNavItemComponent extends StateListener implements Omit<Drawer
 
         this.navItemEl.nativeElement.classList.remove('pxb-drawer-nav-item-active-tree');
 
-        if (!this.drawerService.isEnableSelectionHierarchy()) {
+        if (!this.drawerService.hasEnableSelectionHierarchy()) {
             return;
         }
 

--- a/components/src/core/drawer/drawer-layout/drawer-layout.component.scss
+++ b/components/src/core/drawer/drawer-layout/drawer-layout.component.scss
@@ -8,6 +8,9 @@ $transition: 300ms cubic-bezier(0.4, 0, 0.2, 1);
 /* RTL */
 [dir='rtl'] .pxb-drawer-layout-content .mat-drawer-side {
     border-left: 0; // Border-left is provided by the Drawer component.
+    .pxb-drawer-layout-sidenav {
+        box-shadow: 0 0 -4px 0 #424e54;
+    }
 }
 
 .pxb-drawer-layout-content {
@@ -31,6 +34,10 @@ $transition: 300ms cubic-bezier(0.4, 0, 0.2, 1);
         &.pxb-drawer-collapse {
             width: 100%;
         }
+    }
+
+    .pxb-drawer-layout-sidenav {
+        box-shadow: 0 0 4px 0 #424e54;
     }
 
     .pxb-drawer-layout-sidenav,

--- a/components/src/core/drawer/drawer-layout/drawer-layout.component.scss
+++ b/components/src/core/drawer/drawer-layout/drawer-layout.component.scss
@@ -36,7 +36,7 @@ $transition: 300ms cubic-bezier(0.4, 0, 0.2, 1);
         }
     }
 
-    .pxb-drawer-layout-sidenav.pxb-drawer-layout-side-border  {
+    .pxb-drawer-layout-sidenav.pxb-drawer-layout-side-border {
         box-shadow: 0 0 4px 0 #424e54;
     }
 

--- a/components/src/core/drawer/drawer-layout/drawer-layout.component.scss
+++ b/components/src/core/drawer/drawer-layout/drawer-layout.component.scss
@@ -8,7 +8,7 @@ $transition: 300ms cubic-bezier(0.4, 0, 0.2, 1);
 /* RTL */
 [dir='rtl'] .pxb-drawer-layout-content .mat-drawer-side {
     border-left: 0; // Border-left is provided by the Drawer component.
-    .pxb-drawer-layout-sidenav.pxb-drawer-layout-side-border {
+    .pxb-drawer-layout-sidenav.pxb-drawer-layout-shadow {
         box-shadow: 0 0 -4px 0 #424e54;
     }
 }
@@ -36,7 +36,7 @@ $transition: 300ms cubic-bezier(0.4, 0, 0.2, 1);
         }
     }
 
-    .pxb-drawer-layout-sidenav.pxb-drawer-layout-side-border {
+    .pxb-drawer-layout-sidenav.pxb-drawer-layout-shadow {
         box-shadow: 0 0 4px 0 #424e54;
     }
 

--- a/components/src/core/drawer/drawer-layout/drawer-layout.component.scss
+++ b/components/src/core/drawer/drawer-layout/drawer-layout.component.scss
@@ -8,7 +8,7 @@ $transition: 300ms cubic-bezier(0.4, 0, 0.2, 1);
 /* RTL */
 [dir='rtl'] .pxb-drawer-layout-content .mat-drawer-side {
     border-left: 0; // Border-left is provided by the Drawer component.
-    .pxb-drawer-layout-sidenav {
+    .pxb-drawer-layout-sidenav.pxb-drawer-layout-side-border {
         box-shadow: 0 0 -4px 0 #424e54;
     }
 }
@@ -36,7 +36,7 @@ $transition: 300ms cubic-bezier(0.4, 0, 0.2, 1);
         }
     }
 
-    .pxb-drawer-layout-sidenav {
+    .pxb-drawer-layout-sidenav.pxb-drawer-layout-side-border  {
         box-shadow: 0 0 4px 0 #424e54;
     }
 

--- a/components/src/core/drawer/drawer-layout/drawer-layout.component.ts
+++ b/components/src/core/drawer/drawer-layout/drawer-layout.component.ts
@@ -25,7 +25,7 @@ export type DrawerLayoutVariantType = 'permanent' | 'persistent' | 'temporary' |
                 class="pxb-drawer-layout-sidenav"
                 [fixedInViewport]="false"
                 [class.pxb-drawer-layout-smooth]="variant !== 'temporary'"
-                [class.pxb-drawer-layout-side-border]="hasSideBorder()"
+                [class.pxb-drawer-layout-shadow]="!hasSideBorder()"
                 [style.width.px]="isCollapsed() ? getCollapsedWidth() : width"
                 [mode]="getMode()"
                 [opened]="isDrawerVisible()"

--- a/components/src/core/drawer/drawer-layout/drawer-layout.component.ts
+++ b/components/src/core/drawer/drawer-layout/drawer-layout.component.ts
@@ -25,6 +25,7 @@ export type DrawerLayoutVariantType = 'permanent' | 'persistent' | 'temporary' |
                 class="pxb-drawer-layout-sidenav"
                 [fixedInViewport]="false"
                 [class.pxb-drawer-layout-smooth]="variant !== 'temporary'"
+                [class.pxb-drawer-layout-side-border]="hasSideBorder()"
                 [style.width.px]="isCollapsed() ? getCollapsedWidth() : width"
                 [mode]="getMode()"
                 [opened]="isDrawerVisible()"
@@ -83,6 +84,10 @@ export class DrawerLayoutComponent extends StateListener implements AfterViewIni
 
     getMode(): string {
         return this.variant === 'temporary' ? 'over' : 'side';
+    }
+
+    hasSideBorder(): boolean {
+        return this.drawerService.hasSideBorder();
     }
 
     closeDrawer(): void {

--- a/components/src/core/drawer/drawer.component.scss
+++ b/components/src/core/drawer/drawer.component.scss
@@ -16,6 +16,8 @@ $transition: width 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
     border-right: 0;
     &.pxb-drawer-side-border {
         border-left: 1px solid rgba(0, 0, 0, 0.12);
+    }
+    &:not(.pxb-drawer-side-border) {
         box-shadow: 0 0 -4px 0 #424e54;
     }
     &.temp-variant {
@@ -31,8 +33,10 @@ $transition: width 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
     transition: $transition;
     box-sizing: border-box;
     &.pxb-drawer-side-border {
-        box-shadow: 0 0 4px 0 #424e54;
         border-right: 1px solid rgba(0, 0, 0, 0.12);
+    }
+    &:not(.pxb-drawer-side-border) {
+        box-shadow: 0 0 4px 0 #424e54;
     }
     &.pxb-drawer-temp-variant {
         border-right: 0;

--- a/components/src/core/drawer/drawer.component.scss
+++ b/components/src/core/drawer/drawer.component.scss
@@ -2,6 +2,10 @@ $width-open: 360px;
 $width-closed: 56px;
 $transition: width 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 
+.pxb-drawer-layout .pxb-drawer-content {
+    box-shadow: none; // DrawerLayout has its own side border styles; these are not needed when placed in a PXB DrawerLayout.
+}
+
 .pxb-drawer {
     height: 100%;
     display: flex;
@@ -9,6 +13,7 @@ $transition: width 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 
 /* RTL */
 [dir='rtl'] .pxb-drawer-content {
+    box-shadow: 0 0 -4px 0 #424e54;
     border-right: 0;
     &.pxb-drawer-side-border {
         border-left: 1px solid rgba(0, 0, 0, 0.12);
@@ -19,6 +24,7 @@ $transition: width 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
 .pxb-drawer-content {
+    box-shadow: 0 0 4px 0 #424e54;
     display: flex;
     flex-direction: column;
     height: 100%;

--- a/components/src/core/drawer/drawer.component.scss
+++ b/components/src/core/drawer/drawer.component.scss
@@ -13,10 +13,10 @@ $transition: width 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 
 /* RTL */
 [dir='rtl'] .pxb-drawer-content {
-    box-shadow: 0 0 -4px 0 #424e54;
     border-right: 0;
     &.pxb-drawer-side-border {
         border-left: 1px solid rgba(0, 0, 0, 0.12);
+        box-shadow: 0 0 -4px 0 #424e54;
     }
     &.temp-variant {
         border-left: 0;
@@ -24,7 +24,6 @@ $transition: width 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
 .pxb-drawer-content {
-    box-shadow: 0 0 4px 0 #424e54;
     display: flex;
     flex-direction: column;
     height: 100%;
@@ -32,6 +31,7 @@ $transition: width 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
     transition: $transition;
     box-sizing: border-box;
     &.pxb-drawer-side-border {
+        box-shadow: 0 0 4px 0 #424e54;
         border-right: 1px solid rgba(0, 0, 0, 0.12);
     }
     &.pxb-drawer-temp-variant {

--- a/components/src/core/drawer/drawer.component.ts
+++ b/components/src/core/drawer/drawer.component.ts
@@ -41,6 +41,7 @@ export class DrawerComponent extends StateListener implements OnInit, OnChanges 
     @Input() open: boolean;
     @Input() condensed = false;
     @Input() sideBorder = false;
+    @Input() enableSelectionHierarchy = false;
 
     hoverDelay: any;
     drawerSelectionListener: Subscription;
@@ -59,6 +60,7 @@ export class DrawerComponent extends StateListener implements OnInit, OnChanges 
     ngOnChanges(): void {
         this.drawerService.setDrawerOpen(this.open);
         this.drawerService.setIsCondensed(this.condensed);
+        this.drawerService.setEnableSelectionHierarchy(this.enableSelectionHierarchy);
     }
 
     hoverDrawer(): void {

--- a/components/src/core/drawer/drawer.component.ts
+++ b/components/src/core/drawer/drawer.component.ts
@@ -58,6 +58,7 @@ export class DrawerComponent extends StateListener implements OnInit, OnChanges 
 
     // This broadcasts changes to all of the drawer state listeners.
     ngOnChanges(): void {
+        this.drawerService.setSideBorder(this.sideBorder);
         this.drawerService.setDrawerOpen(this.open);
         this.drawerService.setIsCondensed(this.condensed);
         this.drawerService.setEnableSelectionHierarchy(this.enableSelectionHierarchy);

--- a/components/src/core/drawer/drawer.component.ts
+++ b/components/src/core/drawer/drawer.component.ts
@@ -41,7 +41,7 @@ export class DrawerComponent extends StateListener implements OnInit, OnChanges 
     @Input() open: boolean;
     @Input() condensed = false;
     @Input() sideBorder = false;
-    @Input() enableSelectionHierarchy = true;
+    @Input() disableActiveItemParentStyles = false;
 
     hoverDelay: any;
     drawerSelectionListener: Subscription;
@@ -61,7 +61,7 @@ export class DrawerComponent extends StateListener implements OnInit, OnChanges 
         this.drawerService.setSideBorder(this.sideBorder);
         this.drawerService.setDrawerOpen(this.open);
         this.drawerService.setIsCondensed(this.condensed);
-        this.drawerService.setEnableSelectionHierarchy(this.enableSelectionHierarchy);
+        this.drawerService.setDisableActiveItemParentStyles(this.disableActiveItemParentStyles);
     }
 
     hoverDrawer(): void {

--- a/components/src/core/drawer/drawer.component.ts
+++ b/components/src/core/drawer/drawer.component.ts
@@ -41,7 +41,7 @@ export class DrawerComponent extends StateListener implements OnInit, OnChanges 
     @Input() open: boolean;
     @Input() condensed = false;
     @Input() sideBorder = false;
-    @Input() enableSelectionHierarchy = false;
+    @Input() enableSelectionHierarchy = true;
 
     hoverDelay: any;
     drawerSelectionListener: Subscription;

--- a/components/src/core/drawer/service/drawer.service.ts
+++ b/components/src/core/drawer/service/drawer.service.ts
@@ -12,10 +12,19 @@ export class DrawerService {
     private navItemCount = 0;
     private tempOpen = false;
     private isCondensed: boolean;
+    private sideBorder: boolean;
 
     drawerOpenObs = new Subject<boolean>();
     drawerSelectObs = new Subject<boolean>();
     drawerActiveItemChangeObs = new Subject<boolean>();
+
+    hasSideBorder(): boolean {
+        return this.sideBorder;
+    }
+
+    setSideBorder(sideBorder: boolean): void {
+        this.sideBorder = sideBorder;
+    }
 
     setEnableSelectionHierarchy(enableSelectionHierarchy: boolean): void {
         this.enableSelectionHierarchy = enableSelectionHierarchy;

--- a/components/src/core/drawer/service/drawer.service.ts
+++ b/components/src/core/drawer/service/drawer.service.ts
@@ -30,7 +30,7 @@ export class DrawerService {
         this.enableSelectionHierarchy = enableSelectionHierarchy;
     }
 
-    isEnableSelectionHierarchy(): boolean {
+    hasEnableSelectionHierarchy(): boolean {
         return this.enableSelectionHierarchy;
     }
 

--- a/components/src/core/drawer/service/drawer.service.ts
+++ b/components/src/core/drawer/service/drawer.service.ts
@@ -7,7 +7,7 @@ import { DrawerLayoutVariantType } from '../..';
 })
 export class DrawerService {
     private drawerOpen: boolean;
-    private enableSelectionHierarchy: boolean;
+    private disableActiveItemParentStyles: boolean;
     private variant: DrawerLayoutVariantType;
     private navItemCount = 0;
     private tempOpen = false;
@@ -26,12 +26,12 @@ export class DrawerService {
         this.sideBorder = sideBorder;
     }
 
-    setEnableSelectionHierarchy(enableSelectionHierarchy: boolean): void {
-        this.enableSelectionHierarchy = enableSelectionHierarchy;
+    setDisableActiveItemParentStyles(disableActiveItemParentStyles: boolean): void {
+        this.disableActiveItemParentStyles = disableActiveItemParentStyles;
     }
 
-    hasEnableSelectionHierarchy(): boolean {
-        return this.enableSelectionHierarchy;
+    hasDisableActiveItemParentStyles(): boolean {
+        return this.disableActiveItemParentStyles;
     }
 
     setDrawerTempOpen(open: boolean): void {

--- a/components/src/core/drawer/service/drawer.service.ts
+++ b/components/src/core/drawer/service/drawer.service.ts
@@ -7,13 +7,23 @@ import { DrawerLayoutVariantType } from '../..';
 })
 export class DrawerService {
     private drawerOpen: boolean;
+    private enableSelectionHierarchy: boolean;
     private variant: DrawerLayoutVariantType;
     private navItemCount = 0;
     private tempOpen = false;
     private isCondensed: boolean;
+
     drawerOpenObs = new Subject<boolean>();
     drawerSelectObs = new Subject<boolean>();
     drawerActiveItemChangeObs = new Subject<boolean>();
+
+    setEnableSelectionHierarchy(enableSelectionHierarchy: boolean): void {
+        this.enableSelectionHierarchy = enableSelectionHierarchy;
+    }
+
+    isEnableSelectionHierarchy(): boolean {
+        return this.enableSelectionHierarchy;
+    }
 
     setDrawerTempOpen(open: boolean): void {
         this.tempOpen = open;

--- a/demos/storybook/stories/drawer/with-full-config.stories.ts
+++ b/demos/storybook/stories/drawer/with-full-config.stories.ts
@@ -117,7 +117,7 @@ export const withFullConfig = (): any => ({
         <pxb-drawer 
             [open]="state.open" 
             [sideBorder]="sideBorder"
-            [enableSelectionHierarchy]="enableSelectionHierarchy" 
+            [disableActiveItemParentStyles]="disableActiveItemParentStyles" 
             [class.show-header-image]="showHeaderImage">
            <pxb-drawer-header [title]="title" [subtitle]="subtitle" [divider]="showHeaderDivider">
              <button pxb-icon mat-icon-button (click)="toggleDrawer(state)">
@@ -170,7 +170,7 @@ export const withFullConfig = (): any => ({
         footerImage: footerImage,
         headerImage: headerImage,
         sideBorder: boolean('sideBorder', true, drawer),
-        enableSelectionHierarchy: boolean('enableSelectionHierarchy', true, drawer),
+        disableActiveItemParentStyles: boolean('disableActiveItemParentStyles', false, drawer),
         title: text('title', 'PX Blue Drawer', header),
         subtitle: text('subtitle', 'with full config', header),
         showHeaderImage: boolean('Show Background Image', true, header),

--- a/demos/storybook/stories/drawer/with-full-config.stories.ts
+++ b/demos/storybook/stories/drawer/with-full-config.stories.ts
@@ -5,6 +5,7 @@ import * as Colors from '@pxblue/colors';
 const footerImage = require('../../assets/EatonLogo.svg');
 const headerImage = require('../../assets/topology_40.png');
 
+const drawer = 'Drawer';
 const header = 'DrawerHeader';
 const navGroup = 'DrawerNavGroup';
 const navItem = 'DrawerNavItem';
@@ -113,7 +114,11 @@ export const withFullConfig = (): any => ({
        `,
     ],
     template: `
-        <pxb-drawer [open]="state.open" [class.show-header-image]="showHeaderImage">
+        <pxb-drawer 
+            [open]="state.open" 
+            [sideBorder]="sideBorder"
+            [enableSelectionHierarchy]="enableSelectionHierarchy" 
+            [class.show-header-image]="showHeaderImage">
            <pxb-drawer-header [title]="title" [subtitle]="subtitle" [divider]="showHeaderDivider">
              <button pxb-icon mat-icon-button (click)="toggleDrawer(state)">
                <mat-icon>menu</mat-icon>
@@ -130,7 +135,6 @@ export const withFullConfig = (): any => ({
                       [statusColor]="navItem.statusColor"
                       [hidePadding]="hidePadding"
                       [divider]="itemDivider"
-                      [enableSelectionHierarchy]="enableSelectionHierarchy"
                       [activeItemBackgroundShape]="activeItemBackgroundShape"
                       (select)="navItem.onSelect(); setActive(navItem, state);">
                         <mat-icon *ngIf="showNavItemIcon" pxb-icon>{{ navItem.icon }}</mat-icon>
@@ -141,13 +145,11 @@ export const withFullConfig = (): any => ({
                            [hidePadding]="hidePaddingNested"
                            [selected]="state.selected === nestedItem.title"
                            [activeItemBackgroundShape]="activeItemBackgroundShape"
-                           [enableSelectionHierarchy]="enableSelectionHierarchy"
                            (select)="nestedItem.onSelect(); setActive(nestedItem, state);">       
                             <pxb-drawer-nav-item *ngFor="let deep of nestedItem.items"
                                [title]="deep.title"
                                [hidePadding]="hidePaddingNested"
                                [selected]="state.selected === deep.title"
-                               [enableSelectionHierarchy]="enableSelectionHierarchy"
                                [activeItemBackgroundShape]="activeItemBackgroundShape"
                                (select)="deep.onSelect(); setActive(deep, state);">       
                            </pxb-drawer-nav-item>                    
@@ -167,6 +169,8 @@ export const withFullConfig = (): any => ({
         navItems2: navItems2,
         footerImage: footerImage,
         headerImage: headerImage,
+        sideBorder: boolean('sideBorder', true, drawer),
+        enableSelectionHierarchy: boolean('enableSelectionHierarchy', false, drawer),
         title: text('title', 'PX Blue Drawer', header),
         subtitle: text('subtitle', 'with full config', header),
         showHeaderImage: boolean('Show Background Image', true, header),
@@ -197,7 +201,6 @@ export const withFullConfig = (): any => ({
             },
             navGroup
         ),
-        enableSelectionHierarchy: boolean('enableSelectionHierarchy', false, navItem),
         chevron: boolean('chevron', false, navItem),
         hidePadding: boolean('hidePadding', true, navItem),
         hidePaddingNested: boolean('hidePadding (nested)', false, navItem),

--- a/demos/storybook/stories/drawer/with-full-config.stories.ts
+++ b/demos/storybook/stories/drawer/with-full-config.stories.ts
@@ -170,7 +170,7 @@ export const withFullConfig = (): any => ({
         footerImage: footerImage,
         headerImage: headerImage,
         sideBorder: boolean('sideBorder', true, drawer),
-        enableSelectionHierarchy: boolean('enableSelectionHierarchy', false, drawer),
+        enableSelectionHierarchy: boolean('enableSelectionHierarchy', true, drawer),
         title: text('title', 'PX Blue Drawer', header),
         subtitle: text('subtitle', 'with full config', header),
         showHeaderImage: boolean('Show Background Image', true, header),

--- a/demos/storybook/stories/drawer/with-nested-nav-items.stories.ts
+++ b/demos/storybook/stories/drawer/with-nested-nav-items.stories.ts
@@ -41,7 +41,7 @@ export const nestedNavGroup: DrawerNavItem[] = [
 
 export const withNestedNavItems = (): any => ({
     template: `
-        <pxb-drawer [open]="state.open">
+        <pxb-drawer [open]="state.open" [enableSelectionHierarchy]="enableSelectionHierarchy">
            <pxb-drawer-header title="PX Blue Drawer" subtitle="with nested nav items">
              <button pxb-icon mat-icon-button (click)="toggleDrawer(state)">
                <mat-icon>menu</mat-icon>
@@ -54,19 +54,16 @@ export const withNestedNavItems = (): any => ({
                      [divider]="divider"
                      [hidePadding]="hidePadding"
                      [selected]="state.selected === navItem.title"
-                     [enableSelectionHierarchy]="enableSelectionHierarchy"
                      (select)="navItem.onSelect(); setActive(navItem, state);">
                      <mat-icon *ngIf="showIcon" pxb-icon>{{ navItem.icon }}</mat-icon>
                      <pxb-drawer-nav-item *ngFor="let nestedItem of navItem.items"
                        [title]="nestedItem.title"
                        [divider]="dividerNested"
                        [hidePadding]="hidePaddingNested"
-                       [enableSelectionHierarchy]="enableSelectionHierarchy"
                        [selected]="state.selected === nestedItem.title"
                        (select)="nestedItem.onSelect(); setActive(nestedItem, state);">
                         <pxb-drawer-nav-item *ngFor="let deepItem of nestedItem.items"
                            [title]="deepItem.title"                    
-                           [enableSelectionHierarchy]="enableSelectionHierarchy"
                            [divider]="dividerNested"
                            [hidePadding]="hidePaddingNested"
                            [selected]="state.selected === deepItem.title"

--- a/demos/storybook/stories/drawer/with-nested-nav-items.stories.ts
+++ b/demos/storybook/stories/drawer/with-nested-nav-items.stories.ts
@@ -82,7 +82,7 @@ export const withNestedNavItems = (): any => ({
         dividerNested: boolean('divider (nested)', false),
         hidePadding: boolean('hidePadding (top)', false),
         hidePaddingNested: boolean('hidePadding (nested)', false),
-        enableSelectionHierarchy: boolean('enableSelectionHierarchy', false),
+        enableSelectionHierarchy: boolean('enableSelectionHierarchy', true),
         setActive: (item: DrawerNavItem, state: { selected: string }): void => {
             if (!item.items) {
                 // Only selects items that do not have nested nav items.

--- a/demos/storybook/stories/drawer/with-nested-nav-items.stories.ts
+++ b/demos/storybook/stories/drawer/with-nested-nav-items.stories.ts
@@ -41,7 +41,7 @@ export const nestedNavGroup: DrawerNavItem[] = [
 
 export const withNestedNavItems = (): any => ({
     template: `
-        <pxb-drawer [open]="state.open" [enableSelectionHierarchy]="enableSelectionHierarchy">
+        <pxb-drawer [open]="state.open" [disableActiveItemParentStyles]="disableActiveItemParentStyles">
            <pxb-drawer-header title="PX Blue Drawer" subtitle="with nested nav items">
              <button pxb-icon mat-icon-button (click)="toggleDrawer(state)">
                <mat-icon>menu</mat-icon>
@@ -82,7 +82,7 @@ export const withNestedNavItems = (): any => ({
         dividerNested: boolean('divider (nested)', false),
         hidePadding: boolean('hidePadding (top)', false),
         hidePaddingNested: boolean('hidePadding (nested)', false),
-        enableSelectionHierarchy: boolean('enableSelectionHierarchy', true),
+        disableActiveItemParentStyles: boolean('disableActiveItemParentStyles', false),
         setActive: (item: DrawerNavItem, state: { selected: string }): void => {
             if (!item.items) {
                 // Only selects items that do not have nested nav items.

--- a/docs/Drawer.md
+++ b/docs/Drawer.md
@@ -26,7 +26,7 @@ Parent element (`<pxb-drawer>`) attributes:
 | @Input                        | Description                                                   | Type      | Required | Default |
 | ----------------------------- | ------------------------------------------------------------- | --------- | -------- | ------- |
 | condensed                     | Skinny view for `rail` variant                                | `boolean` | no       | false   |
-| disableActiveItemParentStyles | Bold nav item group title when a nested item is selected      | `boolean` | no       | false   |
+| disableActiveItemParentStyles | If true, NavItems will not have a bold title when a child NavItem is selected | `boolean` | no       | false   |
 | open                          | State for the drawer                                          | `boolean` | yes      |         |
 | sideBorder                    | Toggle a side border instead of shadow                        | `boolean` | no       | false   |
 

--- a/docs/Drawer.md
+++ b/docs/Drawer.md
@@ -23,11 +23,12 @@ Parent element (`<pxb-drawer>`) attributes:
 
 <div style="overflow: auto;">
 
-| @Input     | Description                            | Type      | Required | Default |
-| ---------- | -------------------------------------- | --------- | -------- | ------- |
-| condensed  | Skinny view for `rail` variant         | `boolean` | no       | false   |
-| open       | State for the drawer                   | `boolean` | yes      |         |
-| sideBorder | Toggle a side border instead of shadow | `boolean` | no       | false   |
+| @Input                   | Description                                                   | Type      | Required | Default |
+| ------------------------ | ------------------------------------------------------------- | --------- | -------- | ------- |
+| condensed                | Skinny view for `rail` variant                                | `boolean` | no       | false   |
+| enableSelectionHierarchy | Bold nav item group title when a nested item is selected      | `boolean` | no       | false   |
+| open                     | State for the drawer                                          | `boolean` | yes      |         |
+| sideBorder               | Toggle a side border instead of shadow                        | `boolean` | no       | false   |
 
 > ** The `condensed` attribute won't have any effect on the `<pxb-drawer>` unless the `rail` variant is set on the `<pxb-drawer-layout>` component.  Each item in a navigation rail will be sized 72 x 72px.  When using a `condensed` rail, each item will be sized 56 x 56px.
 

--- a/docs/Drawer.md
+++ b/docs/Drawer.md
@@ -26,7 +26,7 @@ Parent element (`<pxb-drawer>`) attributes:
 | @Input                   | Description                                                   | Type      | Required | Default |
 | ------------------------ | ------------------------------------------------------------- | --------- | -------- | ------- |
 | condensed                | Skinny view for `rail` variant                                | `boolean` | no       | false   |
-| enableSelectionHierarchy | Bold nav item group title when a nested item is selected      | `boolean` | no       | false   |
+| enableSelectionHierarchy | Bold nav item group title when a nested item is selected      | `boolean` | no       | true    |
 | open                     | State for the drawer                                          | `boolean` | yes      |         |
 | sideBorder               | Toggle a side border instead of shadow                        | `boolean` | no       | false   |
 

--- a/docs/Drawer.md
+++ b/docs/Drawer.md
@@ -23,12 +23,12 @@ Parent element (`<pxb-drawer>`) attributes:
 
 <div style="overflow: auto;">
 
-| @Input                   | Description                                                   | Type      | Required | Default |
-| ------------------------ | ------------------------------------------------------------- | --------- | -------- | ------- |
-| condensed                | Skinny view for `rail` variant                                | `boolean` | no       | false   |
-| enableSelectionHierarchy | Bold nav item group title when a nested item is selected      | `boolean` | no       | true    |
-| open                     | State for the drawer                                          | `boolean` | yes      |         |
-| sideBorder               | Toggle a side border instead of shadow                        | `boolean` | no       | false   |
+| @Input                        | Description                                                   | Type      | Required | Default |
+| ----------------------------- | ------------------------------------------------------------- | --------- | -------- | ------- |
+| condensed                     | Skinny view for `rail` variant                                | `boolean` | no       | false   |
+| disableActiveItemParentStyles | Bold nav item group title when a nested item is selected      | `boolean` | no       | false   |
+| open                          | State for the drawer                                          | `boolean` | yes      |         |
+| sideBorder                    | Toggle a side border instead of shadow                        | `boolean` | no       | false   |
 
 > ** The `condensed` attribute won't have any effect on the `<pxb-drawer>` unless the `rail` variant is set on the `<pxb-drawer-layout>` component.  Each item in a navigation rail will be sized 72 x 72px.  When using a `condensed` rail, each item will be sized 56 x 56px.
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
         "lint:fix": "cd components && yarn lint:fix && cd ../demos/showcase && yarn lint:fix && cd ../storybook && yarn lint:fix",
         "prettier": "cd components && yarn prettier && cd ../demos/showcase && yarn prettier && cd ../storybook && yarn prettier",
         "prettier:check": "cd components && yarn prettier:check && cd ../demos/showcase && yarn prettier:check && cd ../storybook && yarn prettier:check",
-        "precommit": "yarn initialize && yarn install:dependencies && yarn prettier && yarn lint && yarn test && yarn build && yarn test:artifacts"
+        "precommit": "yarn initialize && yarn install:dependencies && yarn prettier && yarn lint && yarn test && yarn build && yarn test:artifacts",
+        "update:submodule": "git submodule update --remote"
     },
     "private": true,
     "repository": {


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Add a 4px shadow to the Drawer by default.
- When `Drawer` `sideBorder` prop is `false`, shadow is gone.
- Add `enableSelectionHierarchy` prop to `Drawer`, update storybook stories and docs.


<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
![image](https://user-images.githubusercontent.com/6538289/99008909-14e49e00-2515-11eb-8175-fd6a02ad589b.png)
