### PR TITLE
Fix mobile stepper width bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v4.0.1
+
+-   Style change in `<pxb-mobile-stepper>` to span full width of parent element.
+
 ## v4.0.0
 
 -   Migrated to Angular 10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## v4.0.1
+## v4.0.1 (Not Published Yet)
 
 -   Style change in `<pxb-mobile-stepper>` to span full width of parent element.
 

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pxblue/angular-components",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Angular components for PX Blue applications",
   "scripts": {
     "ng": "ng",

--- a/components/src/core/mobile-stepper/mobile-stepper.component.scss
+++ b/components/src/core/mobile-stepper/mobile-stepper.component.scss
@@ -1,5 +1,6 @@
 .pxb-mobile-stepper {
     display: flex;
+    width: 100%;
 }
 
 .pxb-mobile-stepper-content {


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #197 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Mobile Stepper now takes up 100% width of parent element.
- All storybook examples look the same.
