### PR TITLE
Fix Condensed Rail Tooltip Issue Storybook

### DIFF
--- a/demos/storybook/stories/drawer/with-nav-rail.stories.ts
+++ b/demos/storybook/stories/drawer/with-nav-rail.stories.ts
@@ -57,7 +57,7 @@ export const withNavRail = (): any => ({
     props: {
         navItems: navItems,
         headerImg: headerImg,
-        condensed: boolean('condensed', false),
+        condensed: boolean('condensed', true),
         divider: boolean('divider', false),
     },
 });


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #199

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- If `condensed=true` is the default, storybook no longer has issues with creating/destroying tooltips. 

