### PR TITLE
Add prop to disable drawer open on hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,39 +2,54 @@
 
 ## v4.0.1 (Not Published Yet)
 
--   Style change in `<pxb-mobile-stepper>` to span full width of parent element.
+### Added
+-   Added new property `openOnHover` to `<pxb-drawer>`.
+
+### Fixed
+-   Fixed bug in `<pxb-mobile-stepper>` which makes component span 100% of parent width. 
 
 ## v4.0.0
 
--   Migrated to Angular 10
--   Enhanced `<pxb-empty-state>` to allow ng-content as `title` or `description`.
+### Added
 -   Added `hidden` prop to the `<pxb-drawer-nav-item>`.
+-   Enhanced `<pxb-empty-state>` to allow ng-content as `title` or `description`.
+
+### Changed 
+-   Migrated to Angular 10
 -   Renamed several classes and updated styles for the `<pxb-drawer>`
 -   Updated default style of the `<pxb-hero>`
 
 ## v3.0.1
 
+### Fixed 
 -   Fixes bug in InfoListItem where divider was not working with `mat-ripple`.
 -   Changes default display setting of ListItemTag so it doesn't take up 100% width in non-flex containers.
 -   Updates the ListItemTag styles to match our DSM recommendations.
 
 ## v3.0.0
 
+### Added
 -   Adds a new `rail` variant to the `<pxb-drawer-layout>`.
--   Removed right-to-left icon inverting logic per [Material Design's bidirectionality guideline](https://material.io/design/usability/bidirectionality.html#mirroring-layout).
 -   Adds a host class to each PX Blue component tag
+
+### Changed
+-   Removed right-to-left icon inverting logic per [Material Design's bidirectionality guideline](https://material.io/design/usability/bidirectionality.html#mirroring-layout).
 
 ## v2.1.0
 
+### Added
 -   Adds new component for `<pxb-user-menu>` (use @pxblue/angular-themes v5.1.0+ to get PX Blue themes for this component).
 -   Adds new component for `<pxb-dropdown-toolbar>`.
 -   Adds `iconAlign` attribute to `<pxb-info-list-item>` to align icons left (default), center or right.
 
 ## v2.0.0
 
+### Added
 -   Adds new components for `<pxb-score-card>`, `<pxb-info-list-item>`, `<pxb-list-item-tag>`, and `<pxb-spacer>`.
 -   `<pxb-channel-value>`'s value attribute now accepts both `string` type and `number` type.
 -   Enables support for Angular 9+.
+
+### Changed
 -   Updates colors for accessibility
 
     _Breaking Changes_
@@ -48,22 +63,30 @@
 
 ## v1.3.0
 
+### Added
 -   Creates a storybook demo application
+
+### Fixed
 -   Fixes bug in `<pxb-channel-value>` where font size input was not being used
 
 ## v1.2.1
 
+### Added
 -   Adds a new component for `<pxb-empty-state>`
 -   New index file for simpler import syntax
     -   `import {XXX} from '@pxblue/angular-components'`
 
 ## v1.1.0
 
+### Added
 -   Enables support for Angular 7+
 
 ## v1.0.0
 
+### Added
 -   Angular 7-compatible components
+
+### Fixed
 -   Minor styling fixes
 
 ## v0.0.1

--- a/components/src/core/drawer/drawer.component.ts
+++ b/components/src/core/drawer/drawer.component.ts
@@ -42,6 +42,7 @@ export class DrawerComponent extends StateListener implements OnInit, OnChanges 
     @Input() condensed = false;
     @Input() sideBorder = false;
     @Input() disableActiveItemParentStyles = false;
+    @Input() openOnHover = true;
 
     hoverDelay: any;
     drawerSelectionListener: Subscription;
@@ -65,7 +66,7 @@ export class DrawerComponent extends StateListener implements OnInit, OnChanges 
     }
 
     hoverDrawer(): void {
-        if (!this.open) {
+        if (!this.open && this.openOnHover) {
             this.hoverDelay = setTimeout(() => {
                 this.drawerService.setDrawerTempOpen(true);
                 this.changeDetector.detectChanges();
@@ -74,10 +75,12 @@ export class DrawerComponent extends StateListener implements OnInit, OnChanges 
     }
 
     unhoverDrawer(): void {
-        clearTimeout(this.hoverDelay);
-        if (this.drawerService.isTempOpen()) {
-            this.drawerService.setDrawerTempOpen(false);
-            this.changeDetector.detectChanges();
+        if (this.openOnHover) {
+            clearTimeout(this.hoverDelay);
+            if (this.drawerService.isTempOpen()) {
+                this.drawerService.setDrawerTempOpen(false);
+                this.changeDetector.detectChanges();
+            }
         }
     }
 

--- a/demos/storybook/stories/drawer/with-full-config.stories.ts
+++ b/demos/storybook/stories/drawer/with-full-config.stories.ts
@@ -118,6 +118,7 @@ export const withFullConfig = (): any => ({
             [open]="state.open" 
             [sideBorder]="sideBorder"
             [disableActiveItemParentStyles]="disableActiveItemParentStyles" 
+            [openOnHover]="openOnHover"
             [class.show-header-image]="showHeaderImage">
            <pxb-drawer-header [title]="title" [subtitle]="subtitle" [divider]="showHeaderDivider">
              <button pxb-icon mat-icon-button (click)="toggleDrawer(state)">
@@ -169,6 +170,7 @@ export const withFullConfig = (): any => ({
         navItems2: navItems2,
         footerImage: footerImage,
         headerImage: headerImage,
+        openOnHover: boolean('openOnHover', true, drawer),
         sideBorder: boolean('sideBorder', true, drawer),
         disableActiveItemParentStyles: boolean('disableActiveItemParentStyles', false, drawer),
         title: text('title', 'PX Blue Drawer', header),

--- a/docs/Drawer.md
+++ b/docs/Drawer.md
@@ -23,12 +23,13 @@ Parent element (`<pxb-drawer>`) attributes:
 
 <div style="overflow: auto;">
 
-| @Input                        | Description                                                   | Type      | Required | Default |
-| ----------------------------- | ------------------------------------------------------------- | --------- | -------- | ------- |
-| condensed                     | Skinny view for `rail` variant                                | `boolean` | no       | false   |
-| disableActiveItemParentStyles | If true, NavItems will not have a bold title when a child NavItem is selected | `boolean` | no       | false   |
-| open                          | State for the drawer                                          | `boolean` | yes      |         |
-| sideBorder                    | Toggle a side border instead of shadow                        | `boolean` | no       | false   |
+| @Input                        | Description                                                                          | Type      | Required | Default |
+| ----------------------------- | ------------------------------------------------------------------------------------ | --------- | -------- | ------- |
+| condensed                     | Skinny view for `rail` variant                                                       | `boolean` | no       | false   |
+| disableActiveItemParentStyles | If true, NavItems will not have a bold title when a child NavItem is selected        | `boolean` | no       | false   |
+| openOnHover                   | Automatically open the drawer on hover when closed                                   | `boolean` | no       | true    |
+| open                          | State for the drawer                                                                 | `boolean` | yes      |         |
+| sideBorder                    | Toggle a side border instead of shadow                                               | `boolean` | no       | false   |
 
 > ** The `condensed` attribute won't have any effect on the `<pxb-drawer>` unless the `rail` variant is set on the `<pxb-drawer-layout>` component.  Each item in a navigation rail will be sized 72 x 72px.  When using a `condensed` rail, each item will be sized 56 x 56px.
 

--- a/docs/Drawer.md
+++ b/docs/Drawer.md
@@ -27,7 +27,7 @@ Parent element (`<pxb-drawer>`) attributes:
 | ----------------------------- | ------------------------------------------------------------------------------------ | --------- | -------- | ------- |
 | condensed                     | Skinny view for `rail` variant                                                       | `boolean` | no       | false   |
 | disableActiveItemParentStyles | If true, NavItems will not have a bold title when a child NavItem is selected        | `boolean` | no       | false   |
-| openOnHover                   | Automatically open the drawer on hover when closed (persistent variant only)                                  | `boolean` | no       | true    |
+| openOnHover                   | Automatically open the drawer on hover when closed (persistent variant only)         | `boolean` | no       | true    |
 | open                          | State for the drawer                                                                 | `boolean` | yes      |         |
 | sideBorder                    | Toggle a side border instead of shadow                                               | `boolean` | no       | false   |
 


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #204 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Add new prop `openOnHover` to disable automatic drawer opening on hover.
