### PR TITLE
Remove flex styling from drawer header tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 -   Fixed bug in `<pxb-mobile-stepper>` which makes component span 100% of parent width. 
+-   Fixed header height bug which affected `<pxb-drawer-header>` in Safari. 
 
 ## v4.0.0
 

--- a/components/src/core/drawer/drawer.component.scss
+++ b/components/src/core/drawer/drawer.component.scss
@@ -46,7 +46,6 @@ $transition: width 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
         width: $width-closed;
     }
 
-    pxb-drawer-header,
     pxb-drawer-subheader,
     pxb-drawer-body,
     pxb-drawer-footer {


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #206 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Fix drawer header height issue; looks good on Chrome and Safari now. 

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
<img width="1325" alt="Screen Shot 2021-01-15 at 9 19 01 PM" src="https://user-images.githubusercontent.com/6538289/104794756-c8694900-5777-11eb-8156-a66e67a7e23c.png">
<img width="573" alt="Screen Shot 2021-01-15 at 9 19 14 PM" src="https://user-images.githubusercontent.com/6538289/104794757-c901df80-5777-11eb-8e50-94fb89e1b824.png">
