### PR TITLE
Remove RTL icon flip from info list item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 -   Fixed misalignment of `<pxb-info-list-item>`'s right content.
 
 ### Removed
--   Removed icon inversion logic from `<pxb-info-list-item>` when viewing right-to-left directionality.
+-   Removed automatic RTL flip logic from user-provided icons to `<pxb-info-list-item>`.
 
 ## v4.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 -   Fixed header height bug which affected `<pxb-drawer-header>` in Safari.
 -   Fixed misalignment of `<pxb-info-list-item>`'s right content.
 
+### Removed
+-   Removed icon inversion logic from `<pxb-info-list-item>` when viewing right-to-left directionality.
+
 ## v4.0.0
 
 ### Added

--- a/components/src/core/info-list-item/info-list-item.component.scss
+++ b/components/src/core/info-list-item/info-list-item.component.scss
@@ -30,7 +30,6 @@ $denseHeight: 52px;
             margin-left: 16px;
         }
 
-        .pxb-info-list-item-icon-wrapper > *,
         .pxb-chevron {
             @include invert();
         }


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Remove icon flip from RTL InfoListItem (and Drawer) 
