### PR TITLE
Add margins around dropdown arrows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,22 @@
 
 ### Added
 
--   Added new property `openOnHover` to `<pxb-drawer>`.
+-   Adds new property `openOnHover` to `<pxb-drawer>`.
+-   Adds new class `pxb-dropdown-toolbar-subtitle-icon` to `<pxb-dropdown-toolbar>`
 
 ### Fixed
 
--   Fixed bug in `<pxb-mobile-stepper>` which makes component span 100% of parent width.
--   Fixed header height bug which affected `<pxb-drawer-header>` in Safari.
--   Fixed misalignment of `<pxb-info-list-item>`'s right content.
+-   Fixes bug in `<pxb-mobile-stepper>` which makes component span 100% of parent width.
+-   Fixes header height bug which affected `<pxb-drawer-header>` in Safari.
+-   Fixes misalignment of `<pxb-info-list-item>`'s right content.
 
 ### Removed
--   Removed automatic RTL flip logic from user-provided icons to `<pxb-info-list-item>`.
+
+-   Removes automatic RTL flip logic from user-provided icons to `<pxb-info-list-item>`.
+
+### Changed
+
+-   Default styles for `<pxb-dropdown-toolbar>` to for more paddings around the dropdown arrow.
 
 ## v4.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ### Changed
 
--   Default styles for `<pxb-dropdown-toolbar>` to for more paddings around the dropdown arrow.
+-   Default styles of `<pxb-dropdown-toolbar>` for more paddings around the dropdown arrow.
 
 ## v4.0.0
 

--- a/components/src/core/dropdown-toolbar/dropdown-toolbar.component.scss
+++ b/components/src/core/dropdown-toolbar/dropdown-toolbar.component.scss
@@ -37,14 +37,18 @@
         float: left; // for IE11 compatibility
         /* width: fit-content; */
 
-        .rotated-dropdown-arrow {
-            transform: rotate(180deg);
-        }
-
         .pxb-dropdown-toolbar-subtitle {
             line-height: 1.3rem;
             overflow: hidden;
             text-overflow: ellipsis;
+        }
+
+        .pxb-dropdown-toolbar-subtitle-icon {
+            margin: 0 4px;
+        }
+
+        .rotated-dropdown-arrow {
+            transform: rotate(180deg);
         }
     }
 }

--- a/components/src/core/dropdown-toolbar/dropdown-toolbar.component.ts
+++ b/components/src/core/dropdown-toolbar/dropdown-toolbar.component.ts
@@ -18,7 +18,11 @@ import { MatMenuTrigger } from '@angular/material/menu';
                     #menuTrigger="matMenuTrigger"
                 >
                     <span class="pxb-dropdown-toolbar-subtitle mat-subheading-2">{{ subtitle }}</span>
-                    <mat-icon [class.rotated-dropdown-arrow]="menuTrigger.menuOpen">arrow_drop_down</mat-icon>
+                    <mat-icon
+                        class="pxb-dropdown-toolbar-subtitle-icon"
+                        [class.rotated-dropdown-arrow]="menuTrigger.menuOpen"
+                        >arrow_drop_down</mat-icon
+                    >
                 </div>
             </div>
             <ng-content></ng-content>

--- a/docs/DropdownToolbar.md
+++ b/docs/DropdownToolbar.md
@@ -20,17 +20,17 @@ imports: [
 ```html
 // your-component.html
 <pxb-dropdown-toolbar [title]="title" [subtitle]="subtitle">
-  <button mat-icon-button pxb-nav-icon >
-    <mat-icon>menu</mat-icon>
-  </button>
-  <ng-container pxb-toolbar-menu>
-    <button mat-menu-item>Menu Item 1</button>
-    <button mat-menu-item>Menu Item 2</button>
-    <button mat-menu-item>Menu Item 3</button>
-  </ng-container>
-  <div>
-    <button mat-icon-button><mat-icon>home</mat-icon></button>
-  </div>
+    <button mat-icon-button pxb-nav-icon>
+        <mat-icon>menu</mat-icon>
+    </button>
+    <ng-container pxb-toolbar-menu>
+        <button mat-menu-item>Menu Item 1</button>
+        <button mat-menu-item>Menu Item 2</button>
+        <button mat-menu-item>Menu Item 3</button>
+    </ng-container>
+    <div>
+        <button mat-icon-button><mat-icon>home</mat-icon></button>
+    </div>
 </pxb-dropdown-toolbar>
 ```
 
@@ -40,31 +40,32 @@ Parent element (`<pxb-dropdown-toolbar>`) attributes:
 
 <div style="overflow: auto;">
 
-| @Input   | Description                                    | Type                 | Required | Default |
-| -------- | ---------------------------------------------- | -------------------- | -------- | ------- |
-| title    | The text to display for title                  | `string`             | no       |         |
-| subtitle | The text to display subtitle                   | `string`             | no       |         |
+| @Input   | Description                   | Type     | Required | Default |
+| -------- | ----------------------------- | -------- | -------- | ------- |
+| title    | The text to display for title | `string` | no       |         |
+| subtitle | The text to display subtitle  | `string` | no       |         |
 
 </div>
 
 The following child elements are projected into `<pxb-dropdown-toolbar>`:
 
-| Selector          | Description                                  | Required | Default |
-| ----------------- | -------------------------------------------- | -------- | ------- |
-| pxb-nav-icon      | Icon shown on the left                       | no       |         |
-| pxb-toolbar-menu  | Content to be shown within dropdown menu     | no       |         |
+| Selector         | Description                              | Required | Default |
+| ---------------- | ---------------------------------------- | -------- | ------- |
+| pxb-nav-icon     | Icon shown on the left                   | no       |         |
+| pxb-toolbar-menu | Content to be shown within dropdown menu | no       |         |
 
 ### Classes
 
 Each PX Blue component has classes which can be used to override component styles:
 
-| Name                                         | Description                            |
-| -------------------------------------------- | -------------------------------------- |
-| pxb-dropdown-toolbar                         | Styles applied to the tag              |
-| pxb-dropdown-toolbar-content                 | Styles applied to the root element     |
-| pxb-dropdown-toolbar-icon-wrapper            | Styles applied to the left icon        |
-| pxb-dropdown-toolbar-text-content-container  | Styles applied to the text content     |
-| pxb-dropdown-toolbar-title                   | Styles applied to the title            |
-| pxb-dropdown-toolbar-subtitle-container      | Styles applied to the subtitle wrapper |
-| pxb-dropdown-toolbar-subtitle                | Styles applied to the subtitle         |
-| pxb-dropdown-toolbar-menu-wrapper            | Styles applied to the menu             |
+| Name                                        | Description                            |
+| ------------------------------------------- | -------------------------------------- |
+| pxb-dropdown-toolbar                        | Styles applied to the tag              |
+| pxb-dropdown-toolbar-content                | Styles applied to the root element     |
+| pxb-dropdown-toolbar-icon-wrapper           | Styles applied to the left icon        |
+| pxb-dropdown-toolbar-text-content-container | Styles applied to the text content     |
+| pxb-dropdown-toolbar-title                  | Styles applied to the title            |
+| pxb-dropdown-toolbar-subtitle-container     | Styles applied to the subtitle wrapper |
+| pxb-dropdown-toolbar-subtitle               | Styles applied to the subtitle         |
+| pxb-dropdown-toolbar-subtitle-icon          | Styles applied to the subtitle icon    |
+| pxb-dropdown-toolbar-menu-wrapper           | Styles applied to the menu             |

--- a/docs/DropdownToolbar.md
+++ b/docs/DropdownToolbar.md
@@ -66,6 +66,6 @@ Each PX Blue component has classes which can be used to override component style
 | pxb-dropdown-toolbar-text-content-container | Styles applied to the text content     |
 | pxb-dropdown-toolbar-title                  | Styles applied to the title            |
 | pxb-dropdown-toolbar-subtitle-container     | Styles applied to the subtitle wrapper |
-| pxb-dropdown-toolbar-subtitle               | Styles applied to the subtitle         |
 | pxb-dropdown-toolbar-subtitle-icon          | Styles applied to the subtitle icon    |
+| pxb-dropdown-toolbar-subtitle               | Styles applied to the subtitle         |
 | pxb-dropdown-toolbar-menu-wrapper           | Styles applied to the menu             |


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Added `0 4px` margin around the dropdown arrow of dropdown toolbar to match react

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
Before
![image](https://user-images.githubusercontent.com/8997218/105540715-a6664e00-5cc4-11eb-960f-b0016e58dc83.png)
After
![image](https://user-images.githubusercontent.com/8997218/105540731-abc39880-5cc4-11eb-8249-a53f762b0573.png)
