### PR TITLE
Feature/drawer hover delay prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   Adds new class `pxb-dropdown-toolbar-subtitle-icon` to `<pxb-dropdown-toolbar>`
 -   Adds lighter font weight to `<pxb-info-list-item>` placed inside `<pxb-user-menu>`.
 -   Adds a shadow to the `<pxb-user-menu>` when opened.
+-   Adds new property `openOnHoverDelay` to `<pxb-drawer>` to alter open-on-hover delay for closed persistent drawers. 
 
 ### Fixed
 

--- a/components/src/core/drawer/drawer.component.ts
+++ b/components/src/core/drawer/drawer.component.ts
@@ -44,8 +44,9 @@ export class DrawerComponent extends StateListener implements OnInit, OnChanges 
     @Input() sideBorder = false;
     @Input() disableActiveItemParentStyles = false;
     @Input() openOnHover = true;
+    @Input() openOnHoverDelay = 500;
 
-    hoverDelay: any;
+    hoverDelayTimeout: any;
     drawerSelectionListener: Subscription;
 
     constructor(drawerService: DrawerService, changeDetectorRef: ChangeDetectorRef) {
@@ -68,16 +69,16 @@ export class DrawerComponent extends StateListener implements OnInit, OnChanges 
 
     hoverDrawer(): void {
         if (!this.open && this.openOnHover) {
-            this.hoverDelay = setTimeout(() => {
+            this.hoverDelayTimeout = setTimeout(() => {
                 this.drawerService.setDrawerTempOpen(true);
                 this.changeDetector.detectChanges();
-            }, 500);
+            }, this.openOnHoverDelay);
         }
     }
 
     unhoverDrawer(): void {
         if (this.openOnHover) {
-            clearTimeout(this.hoverDelay);
+            clearTimeout(this.hoverDelayTimeout);
             if (this.drawerService.isTempOpen()) {
                 this.drawerService.setDrawerTempOpen(false);
                 this.changeDetector.detectChanges();

--- a/demos/storybook/stories/drawer/with-full-config.stories.ts
+++ b/demos/storybook/stories/drawer/with-full-config.stories.ts
@@ -113,6 +113,7 @@ export const withFullConfig = (): any => ({
     template: `
         <pxb-drawer 
             [open]="state.open" 
+            [openOnHoverDelay]="openOnHoverDelay"
             [sideBorder]="sideBorder"
             [disableActiveItemParentStyles]="disableActiveItemParentStyles" 
             [openOnHover]="openOnHover"
@@ -161,6 +162,17 @@ export const withFullConfig = (): any => ({
         footerImage: footerImage,
         headerImage: headerImage,
         openOnHover: boolean('openOnHover', true, drawer),
+        openOnHoverDelay: number(
+            'openOnHoverDelay',
+            500,
+            {
+                range: true,
+                min: 100,
+                max: 2000,
+                step: 100,
+            },
+            drawer
+        ),
         sideBorder: boolean('sideBorder', true, drawer),
         disableActiveItemParentStyles: boolean('disableActiveItemParentStyles', false, drawer),
         title: text('title', 'PX Blue Drawer', header),

--- a/docs/Drawer.md
+++ b/docs/Drawer.md
@@ -23,13 +23,14 @@ Parent element (`<pxb-drawer>`) attributes:
 
 <div style="overflow: auto;">
 
-| @Input                        | Description                                                                          | Type      | Required | Default |
-| ----------------------------- | ------------------------------------------------------------------------------------ | --------- | -------- | ------- |
-| condensed                     | Skinny view for `rail` variant                                                       | `boolean` | no       | false   |
-| disableActiveItemParentStyles | If true, NavItems will not have a bold title when a child NavItem is selected        | `boolean` | no       | false   |
-| openOnHover                   | Automatically open the drawer on hover when closed (persistent variant only)         | `boolean` | no       | true    |
-| open                          | State for the drawer                                                                 | `boolean` | yes      |         |
-| sideBorder                    | Toggle a side border instead of shadow                                               | `boolean` | no       | false   |
+| @Input                        | Description                                                                            | Type      | Required | Default |
+| ----------------------------- | -------------------------------------------------------------------------------------- | --------- | -------- | ------- |
+| condensed                     | Skinny view for `rail` variant                                                         | `boolean` | no       | false   |
+| disableActiveItemParentStyles | If true, NavItems will not have a bold title when a child NavItem is selected          | `boolean` | no       | false   |
+| openOnHover                   | Automatically open the drawer on hover when closed (persistent variant only)           | `boolean` | no       | true    |
+| open                          | State for the drawer                                                                   | `boolean` | yes      |         |
+| openOnHoverDelay              | Delay in milliseconds before a hover event opens the drawer (persistent variant only)  | `number`  | no       | 500     |
+| sideBorder                    | Toggle a side border instead of shadow                                                 | `boolean` | no       | false   |
 
 > ** The `condensed` attribute won't have any effect on the `<pxb-drawer>` unless the `rail` variant is set on the `<pxb-drawer-layout>` component.  Each item in a navigation rail will be sized 72 x 72px.  When using a `condensed` rail, each item will be sized 56 x 56px.
 


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #219 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Add new prop `openOnHoverDelay` to Drawer so users can adjust time it takes for drawer to open on hover.  Persistent closed drawers only. 


