### PR TITLE
Change menu title font size to 16px

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## v4.0.1 (Not Published Yet)
+## v4.1.0 (Not Published Yet)
 
 ### Added
 
@@ -27,6 +27,7 @@
 ### Changed
 
 -   Default styles of `<pxb-dropdown-toolbar>` for more padding around the dropdown arrow.
+-   Changed `<pxb-user-menu>` menu title default font size to 16px.
 
 ## v4.0.0
 

--- a/components/src/core/user-menu/user-menu.component.scss
+++ b/components/src/core/user-menu/user-menu.component.scss
@@ -39,6 +39,9 @@ mat-card.pxb-user-menu-overlay {
 .pxb-user-menu-header mat-toolbar {
     border-top-left-radius: 4px !important;
     border-top-right-radius: 4px !important;
+    .pxb-drawer-header-title {
+        font-size: 16px;
+    }
 }
 
 .pxb-user-menu-overlay-backdrop {


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #211 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Font size of UserMenu title is now 16px

