### PR TITLE
Remove hard-coded white badge bg color from scorecard demo

### DIFF
--- a/demos/storybook/package.json
+++ b/demos/storybook/package.json
@@ -24,7 +24,7 @@
         "@angular/material": "^10.1.4",
         "@angular/platform-browser": "~10.1.4",
         "@angular/platform-browser-dynamic": "~10.1.4",
-        "@pxblue/angular-themes": "^6.0.0-beta.0",
+        "@pxblue/angular-themes": "^6.0.0-beta.1",
         "@pxblue/colors": "^3.0.0",
         "@pxblue/icons": "^1.0.25",
         "@pxblue/icons-svg": "^1.0.18",

--- a/demos/storybook/stories/score-card/with-full-config.stories.ts
+++ b/demos/storybook/stories/score-card/with-full-config.stories.ts
@@ -55,12 +55,10 @@ export const withFullConfig = (): any => ({
                 </mat-list-item>
             </mat-list>
             <pxb-hero-banner pxb-badge>
-                <pxb-hero *ngIf="heroLimit > 0" [label]="'Temperature'" [value]="'98'"
-                    [units]="'°F'" [iconSize]="72" [iconBackgroundColor]="colors.white[50]">
+                <pxb-hero *ngIf="heroLimit > 0" [label]="'Temperature'" [value]="'98'" [units]="'°F'" [iconSize]="72">
                     <i pxb-primary class="pxb-temp"></i>
                 </pxb-hero>
-                <pxb-hero *ngIf="heroLimit > 1" [label]="'Humidity'" [value]="'54'"
-                    [units]="'%'" [iconSize]="72" [iconBackgroundColor]="colors.white[50]">
+                <pxb-hero *ngIf="heroLimit > 1" [label]="'Humidity'" [value]="'54'" [units]="'%'" [iconSize]="72">
                     <i pxb-primary [style.color]="colors.blue[300]" class="pxb-moisture"></i>
                 </pxb-hero>
             </pxb-hero-banner>

--- a/demos/storybook/stories/score-card/with-score-badge.stories.ts
+++ b/demos/storybook/stories/score-card/with-score-badge.stories.ts
@@ -49,7 +49,7 @@ export const withScoreBadge = (): any => ({
                     <mat-icon mat-list-icon>cloud</mat-icon>
                 </mat-list-item>
             </mat-list>
-            <pxb-hero pxb-badge [label]="'Grade'" [value]="'98'" [units]="'/100'" [iconSize]="72" [iconBackgroundColor]="colors.white[50]">
+            <pxb-hero pxb-badge [label]="'Grade'" [value]="'98'" [units]="'/100'" [iconSize]="72">
                 <i pxb-primary [style.color]="colors.green[500]" class="pxb-grade_a"></i>
             </pxb-hero>
             <pxb-info-list-item pxb-action-row chevron="true" hidePadding="true" dense="true"(click)="actionRowClick()">

--- a/demos/storybook/yarn.lock
+++ b/demos/storybook/yarn.lock
@@ -1647,10 +1647,10 @@
   dependencies:
     mkdirp "^1.0.4"
 
-"@pxblue/angular-themes@^6.0.0-beta.0":
-  version "6.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/@pxblue/angular-themes/-/angular-themes-6.0.0-beta.0.tgz#1d91d3474a9cf1836656ab924445f4fd72531b1b"
-  integrity sha512-TvystZrlSh/owoyegIV020ausl8578uHpetxB185dFGcYHjBajIO/3lu2AallJXdJI6thfKKoJzZPfHymxoDGg==
+"@pxblue/angular-themes@^6.0.0-beta.1":
+  version "6.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@pxblue/angular-themes/-/angular-themes-6.0.0-beta.1.tgz#1b65901e0be902e13e2feeaf1d50bcd487ff7990"
+  integrity sha512-1Z/7A6fMyxGmfaYzFFKjytSP5o7/rJqnvR9O/7Mcc1S3OJgGOlY+NUnAy8DQoWXT8THuL3qKWdeEJwKkI1ooAA==
   dependencies:
     "@fontsource/open-sans" "^4.1.0"
     "@pxblue/colors" "^3.0.0"


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Removes hard-coded white[50] badge background from storybook ScoreCard examples. 
- This should only be merged in when we have the latest @pxblue/angular-themes published. 