### PR TITLE
Add default margin to EmptyState action button icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 -   Default styles of `<pxb-dropdown-toolbar>` for more padding around the dropdown arrow.
 -   Changed `<pxb-user-menu>` menu title default font size to 16px.
+-   Changed default `<pxb-empty-state>` button icon default margin. 
 
 ## v4.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@
 
 -   Default styles of `<pxb-dropdown-toolbar>` for more padding around the dropdown arrow.
 -   Changed `<pxb-user-menu>` menu title default font size to 16px.
--   Changed default `<pxb-empty-state>` button icon default margin. 
+-   Changed default `<pxb-empty-state>` action button icon margins. 
+-   Changed default `<pxb-empty-state>` action button icon size to 20px.
 
 ## v4.0.0
 

--- a/components/src/core/empty-state/empty-state.component.scss
+++ b/components/src/core/empty-state/empty-state.component.scss
@@ -1,3 +1,8 @@
+[dir='rtl'] .pxb-empty-state .pxb-empty-state-actions-wrapper mat-icon {
+    margin-right: -4px;
+    margin-left: 8px;
+}
+
 .pxb-empty-state {
     display: flex;
 }
@@ -36,8 +41,17 @@
         }
     }
 
-    .pxb-empty-state-actions-wrapper .mat-button-wrapper {
-        display: flex;
-        align-items: center;
+    .pxb-empty-state-actions-wrapper {
+        .mat-button-wrapper {
+            display: flex;
+            align-items: center;
+        }
+        mat-icon {
+            margin-right: 8px;
+            margin-left: -4px;
+            height: 20px;
+            width: 20px;
+            font-size: 20px;
+        }
     }
 }

--- a/demos/storybook/stories/empty-state/with-actions.stories.ts
+++ b/demos/storybook/stories/empty-state/with-actions.stories.ts
@@ -1,18 +1,12 @@
 import { text } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
-import { getDirection } from '@pxblue/storybook-rtl-addon';
 
 export const withActions = (): any => ({
     template: `
         <pxb-empty-state [title]="title" [description]="description">
             <mat-icon pxb-empty-icon>devices</mat-icon>
             <button pxb-actions mat-stroked-button color="primary" (click)="click()">
-                <mat-icon 
-                    style="height: 20px; width: 20px; font-size: 20px;"
-                    [style.marginRight.px]="direction() === 'rtl' ? -4 : 8"
-                    [style.marginLeft.px]="direction() === 'rtl' ? 8 : -4">
-                    add
-                </mat-icon>
+                <mat-icon>add</mat-icon>
                 {{actionText}}
             </button> 
         </pxb-empty-state>
@@ -22,6 +16,5 @@ export const withActions = (): any => ({
         description: text('description', 'Check your network connection or add a new device'),
         click: action('button clicked'),
         actionText: text('Action Text', 'Add Device'),
-        direction: getDirection,
     },
 });


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Moved storybook styles into component library as default.
- EmptyState action button icon now has some default margins applied to it. 
- Default action button icon font size is 20px.

