### PR TITLE
Feature/user menu font size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 -   Default styles of `<pxb-dropdown-toolbar>` for more padding around the dropdown arrow.
 -   Changed `<pxb-user-menu>` menu title default font size to 16px.
+-   Changed `<pxb-user-menu>` menu subtitle default font size to 14px.
 
 ## v4.0.0
 

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pxblue/angular-components",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "Angular components for PX Blue applications",
   "scripts": {
     "ng": "ng",

--- a/components/src/core/user-menu/user-menu.component.scss
+++ b/components/src/core/user-menu/user-menu.component.scss
@@ -42,6 +42,9 @@ mat-card.pxb-user-menu-overlay {
     .pxb-drawer-header-title {
         font-size: 16px;
     }
+    .pxb-drawer-header-subtitle {
+        font-size: 14px;
+    }
 }
 
 .pxb-user-menu-overlay-backdrop {


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
-  User Menu header subtitle should be 14px 

https://pxblue-angular-library.web.app/?path=/story/components-user-menu--with-a-menu-header

Once this gets merged in we can publish @pxblue/angular-components@4.1.0
