### PR TITLE
Add a sideborder

### DIFF
--- a/demos/storybook/stories/drawer/with-nav-rail.stories.ts
+++ b/demos/storybook/stories/drawer/with-nav-rail.stories.ts
@@ -56,6 +56,6 @@ export const withNavRail = (): any => ({
     props: {
         navItems: navItems,
         condensed: boolean('condensed', true),
-        divider: boolean('divider', false)
+        divider: boolean('divider', false),
     },
 });

--- a/demos/storybook/stories/drawer/with-nav-rail.stories.ts
+++ b/demos/storybook/stories/drawer/with-nav-rail.stories.ts
@@ -33,7 +33,7 @@ export const withNavRail = (): any => ({
     ],
     template: `
         <pxb-drawer-layout variant="rail">
-            <pxb-drawer pxb-drawer [condensed]="condensed">
+            <pxb-drawer pxb-drawer [condensed]="condensed" [sideBorder]="true">
                <pxb-drawer-body>
                   <pxb-drawer-nav-group>
                        <pxb-drawer-nav-item *ngFor="let navItem of navItems"
@@ -56,6 +56,6 @@ export const withNavRail = (): any => ({
     props: {
         navItems: navItems,
         condensed: boolean('condensed', true),
-        divider: boolean('divider', false),
+        divider: boolean('divider', false)
     },
 });

--- a/demos/storybook/stories/drawer/with-nav-rail.stories.ts
+++ b/demos/storybook/stories/drawer/with-nav-rail.stories.ts
@@ -33,7 +33,7 @@ export const withNavRail = (): any => ({
     ],
     template: `
         <pxb-drawer-layout variant="rail">
-            <pxb-drawer pxb-drawer [condensed]="condensed" [sideBorder]="true">
+            <pxb-drawer pxb-drawer [condensed]="condensed" [sideBorder]="sideBorder">
                <pxb-drawer-body>
                   <pxb-drawer-nav-group>
                        <pxb-drawer-nav-item *ngFor="let navItem of navItems"
@@ -51,11 +51,13 @@ export const withNavRail = (): any => ({
                     </div>
                 </pxb-drawer-footer>
             </pxb-drawer>
+            <div pxb-content [style.width.px]="24"></div>
         </pxb-drawer-layout>
       `,
     props: {
         navItems: navItems,
         condensed: boolean('condensed', true),
         divider: boolean('divider', false),
+        sideBorder: boolean('sideBorder', false),
     },
 });


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #236 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Add sideborder to rail story.

A drawer rail cannot exist outside of a DrawerLayout because the `variant` prop is on the DrawerLayout.  The shadow prop is not working in this example because there's no content body to cast the shadow onto.  I've just added a `sideBorder=true` to add a border. 

![image](https://user-images.githubusercontent.com/6538289/109985156-73a37280-7cd2-11eb-9c69-6346d6cb881e.png)
