### PR TITLE
Bug/fix dropdown toolbar rem height

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pxblue/angular-components",
-  "version": "4.2.0-beta.0",
+  "version": "4.2.0-beta.1",
   "description": "Angular components for PX Blue applications",
   "scripts": {
     "ng": "ng",

--- a/components/src/core/dropdown-toolbar/dropdown-toolbar.component.scss
+++ b/components/src/core/dropdown-toolbar/dropdown-toolbar.component.scss
@@ -14,7 +14,7 @@
     display: flex;
 }
 .pxb-dropdown-toolbar-content {
-    height: 4.5rem;
+    height: 4rem;
     .pxb-dropdown-toolbar-icon-wrapper > * {
         margin-right: 32px;
         margin-left: -8px;


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Dropdown toobar height for larger viewports should be 4rem; this matches the default mat-toolbar height of 64px.


