### PR TITLE
Update margin between description and action row for empty state

### DIFF
--- a/components/src/core/empty-state/empty-state.component.scss
+++ b/components/src/core/empty-state/empty-state.component.scss
@@ -15,7 +15,7 @@
     }
 
     .pxb-empty-state-description {
-        margin-bottom: 0.5rem;
+        margin-bottom: 1rem;
     }
 
     .pxb-empty-state-title,


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #240.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Update margin between description and action row for empty state from 0.5rem to 1rem (8px -> 16px)

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
![Screen Shot 2021-03-30 at 9 26 03 AM](https://user-images.githubusercontent.com/13989985/112996409-259b5680-913a-11eb-8f3c-a58a8728ad12.png)
![Screen Shot 2021-03-30 at 9 25 54 AM](https://user-images.githubusercontent.com/13989985/112996411-259b5680-913a-11eb-9064-9563beed7eba.png)