### PR TITLE
[NG-#1]Update package version number to 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,138 +4,138 @@
 
 ### Added
 
-- Added new property `color` to `<pxb-dropdown-toolbar>`.
-- Added new property `color` to `<pxb-drawer-header>`.
+-   Added new property `color` to `<pxb-dropdown-toolbar>`.
+-   Added new property `color` to `<pxb-drawer-header>`.
 
 ### Changed
 
-- Changed vertical margins to use rem units so they scale with system font-size
-- Updated `<pxb-score-card>` header and subtitle font size to match DSM.
+-   Changed vertical margins to use rem units so they scale with system font-size
+-   Updated `<pxb-score-card>` header and subtitle font size to match DSM.
 
 ## v4.1.0
 
 ### Added
 
-- Adds new property `openOnHover` to `<pxb-drawer>`.
-- Adds new class `pxb-dropdown-toolbar-subtitle-icon` to `<pxb-dropdown-toolbar>`
-- Adds lighter font weight to `<pxb-info-list-item>` placed inside `<pxb-user-menu>`.
-- Adds a shadow to the `<pxb-user-menu>` when opened.
-- Adds new property `openOnHoverDelay` to `<pxb-drawer>` to alter open-on-hover delay for closed persistent drawers.
+-   Adds new property `openOnHover` to `<pxb-drawer>`.
+-   Adds new class `pxb-dropdown-toolbar-subtitle-icon` to `<pxb-dropdown-toolbar>`
+-   Adds lighter font weight to `<pxb-info-list-item>` placed inside `<pxb-user-menu>`.
+-   Adds a shadow to the `<pxb-user-menu>` when opened.
+-   Adds new property `openOnHoverDelay` to `<pxb-drawer>` to alter open-on-hover delay for closed persistent drawers.
 
 ### Fixed
 
-- Fixes bug in `<pxb-mobile-stepper>` which makes component span 100% of parent width.
-- Fixes header height bug which affected `<pxb-drawer-header>` in Safari.
-- Fixes misalignment of `<pxb-info-list-item>`'s right content.
-- Fixes RTL styles in `<pxb-dropdown-toolbar>`.
-- Fixes uneven vertical alignment of icon and text in `<pxb-empty-state>` action buttons.
-- Fixes `<pxb-user-menu>` menu header avatar offset.
-- Fixes `<pxb-drawer>` `sideBorder` prop to use `mat-elevation` class.
+-   Fixes bug in `<pxb-mobile-stepper>` which makes component span 100% of parent width.
+-   Fixes header height bug which affected `<pxb-drawer-header>` in Safari.
+-   Fixes misalignment of `<pxb-info-list-item>`'s right content.
+-   Fixes RTL styles in `<pxb-dropdown-toolbar>`.
+-   Fixes uneven vertical alignment of icon and text in `<pxb-empty-state>` action buttons.
+-   Fixes `<pxb-user-menu>` menu header avatar offset.
+-   Fixes `<pxb-drawer>` `sideBorder` prop to use `mat-elevation` class.
 
 ### Removed
 
-- Removes automatic RTL flip logic from user-provided icons to `<pxb-info-list-item>`.
+-   Removes automatic RTL flip logic from user-provided icons to `<pxb-info-list-item>`.
 
 ### Changed
 
-- Default styles of `<pxb-dropdown-toolbar>` for more padding around the dropdown arrow.
-- Changed `<pxb-user-menu>` menu title default font size to 16px.
-- Changed `<pxb-user-menu>` menu subtitle default font size to 14px.
+-   Default styles of `<pxb-dropdown-toolbar>` for more padding around the dropdown arrow.
+-   Changed `<pxb-user-menu>` menu title default font size to 16px.
+-   Changed `<pxb-user-menu>` menu subtitle default font size to 14px.
 
 ## v4.0.0
 
 ### Added
 
-- Added `hidden` prop to the `<pxb-drawer-nav-item>`.
-- Enhanced `<pxb-empty-state>` to allow ng-content as `title` or `description`.
+-   Added `hidden` prop to the `<pxb-drawer-nav-item>`.
+-   Enhanced `<pxb-empty-state>` to allow ng-content as `title` or `description`.
 
 ### Changed
 
-- Migrated to Angular 10
-- Renamed several classes and updated styles for the `<pxb-drawer>`
-- Updated default style of the `<pxb-hero>`
+-   Migrated to Angular 10
+-   Renamed several classes and updated styles for the `<pxb-drawer>`
+-   Updated default style of the `<pxb-hero>`
 
 ## v3.0.1
 
 ### Fixed
 
-- Fixes bug in InfoListItem where divider was not working with `mat-ripple`.
-- Changes default display setting of ListItemTag so it doesn't take up 100% width in non-flex containers.
-- Updates the ListItemTag styles to match our DSM recommendations.
+-   Fixes bug in InfoListItem where divider was not working with `mat-ripple`.
+-   Changes default display setting of ListItemTag so it doesn't take up 100% width in non-flex containers.
+-   Updates the ListItemTag styles to match our DSM recommendations.
 
 ## v3.0.0
 
 ### Added
 
-- Adds a new `rail` variant to the `<pxb-drawer-layout>`.
-- Adds a host class to each PX Blue component tag
+-   Adds a new `rail` variant to the `<pxb-drawer-layout>`.
+-   Adds a host class to each PX Blue component tag
 
 ### Changed
 
-- Removed right-to-left icon inverting logic per [Material Design's bidirectionality guideline](https://material.io/design/usability/bidirectionality.html#mirroring-layout).
+-   Removed right-to-left icon inverting logic per [Material Design's bidirectionality guideline](https://material.io/design/usability/bidirectionality.html#mirroring-layout).
 
 ## v2.1.0
 
 ### Added
 
-- Adds new component for `<pxb-user-menu>` (use @pxblue/angular-themes v5.1.0+ to get PX Blue themes for this component).
-- Adds new component for `<pxb-dropdown-toolbar>`.
-- Adds `iconAlign` attribute to `<pxb-info-list-item>` to align icons left (default), center or right.
+-   Adds new component for `<pxb-user-menu>` (use @pxblue/angular-themes v5.1.0+ to get PX Blue themes for this component).
+-   Adds new component for `<pxb-dropdown-toolbar>`.
+-   Adds `iconAlign` attribute to `<pxb-info-list-item>` to align icons left (default), center or right.
 
 ## v2.0.0
 
 ### Added
 
-- Adds new components for `<pxb-score-card>`, `<pxb-info-list-item>`, `<pxb-list-item-tag>`, and `<pxb-spacer>`.
-- `<pxb-channel-value>`'s value attribute now accepts both `string` type and `number` type.
-- Enables support for Angular 9+.
+-   Adds new components for `<pxb-score-card>`, `<pxb-info-list-item>`, `<pxb-list-item-tag>`, and `<pxb-spacer>`.
+-   `<pxb-channel-value>`'s value attribute now accepts both `string` type and `number` type.
+-   Enables support for Angular 9+.
 
 ### Changed
 
-- Updates colors for accessibility
+-   Updates colors for accessibility
 
-  _Breaking Changes_
+    _Breaking Changes_
 
-- We now switched to use `@pxblue/angular-themes` for our application's default style.
-- Deep imports are deprecated; access modules by importing `@pxblue/angular-components`.
-- `<pxb-empty-state>`'s attribute `empty-icon` has been renamed to `emptyIcon` to reflect the Angular convention.
-- `fontSize` attributes have been removed from `<pxb-hero>` and `<pxb-channel-value>`
-  components. Font size can be set directly through the style attribute: `[fontSize]="20"` => `style="font-size: 20px"`
-- `iconSize` attribute for `<pxb-hero>` now takes only numeric values
+-   We now switched to use `@pxblue/angular-themes` for our application's default style.
+-   Deep imports are deprecated; access modules by importing `@pxblue/angular-components`.
+-   `<pxb-empty-state>`'s attribute `empty-icon` has been renamed to `emptyIcon` to reflect the Angular convention.
+-   `fontSize` attributes have been removed from `<pxb-hero>` and `<pxb-channel-value>`
+    components. Font size can be set directly through the style attribute: `[fontSize]="20"` => `style="font-size: 20px"`
+-   `iconSize` attribute for `<pxb-hero>` now takes only numeric values
 
 ## v1.3.0
 
 ### Added
 
-- Creates a storybook demo application
+-   Creates a storybook demo application
 
 ### Fixed
 
-- Fixes bug in `<pxb-channel-value>` where font size input was not being used
+-   Fixes bug in `<pxb-channel-value>` where font size input was not being used
 
 ## v1.2.1
 
 ### Added
 
-- Adds a new component for `<pxb-empty-state>`
-- New index file for simpler import syntax
-  - `import {XXX} from '@pxblue/angular-components'`
+-   Adds a new component for `<pxb-empty-state>`
+-   New index file for simpler import syntax
+    -   `import {XXX} from '@pxblue/angular-components'`
 
 ## v1.1.0
 
 ### Added
 
-- Enables support for Angular 7+
+-   Enables support for Angular 7+
 
 ## v1.0.0
 
 ### Added
 
-- Angular 7-compatible components
+-   Angular 7-compatible components
 
 ### Fixed
 
-- Minor styling fixes
+-   Minor styling fixes
 
 ## v0.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,141 +1,141 @@
 # Change Log
 
-## v4.2.0 (not yet published)
+## v4.2.0
 
 ### Added
 
--   Adds new property `color` to `<pxb-dropdown-toolbar>`.  
--   Adds new property `color` to `<pxb-drawer-header>`.  
+- Adds new property `color` to `<pxb-dropdown-toolbar>`.
+- Adds new property `color` to `<pxb-drawer-header>`.
 
 ### Changed
 
--   Changed vertical margins to use rem units so they scale with system font-size
--   Updated `<pxb-score-card>` header and subtitle font size to match DSM.
+- Changed vertical margins to use rem units so they scale with system font-size
+- Updated `<pxb-score-card>` header and subtitle font size to match DSM.
 
 ## v4.1.0
 
 ### Added
 
--   Adds new property `openOnHover` to `<pxb-drawer>`.
--   Adds new class `pxb-dropdown-toolbar-subtitle-icon` to `<pxb-dropdown-toolbar>`
--   Adds lighter font weight to `<pxb-info-list-item>` placed inside `<pxb-user-menu>`.
--   Adds a shadow to the `<pxb-user-menu>` when opened.
--   Adds new property `openOnHoverDelay` to `<pxb-drawer>` to alter open-on-hover delay for closed persistent drawers. 
+- Adds new property `openOnHover` to `<pxb-drawer>`.
+- Adds new class `pxb-dropdown-toolbar-subtitle-icon` to `<pxb-dropdown-toolbar>`
+- Adds lighter font weight to `<pxb-info-list-item>` placed inside `<pxb-user-menu>`.
+- Adds a shadow to the `<pxb-user-menu>` when opened.
+- Adds new property `openOnHoverDelay` to `<pxb-drawer>` to alter open-on-hover delay for closed persistent drawers.
 
 ### Fixed
 
--   Fixes bug in `<pxb-mobile-stepper>` which makes component span 100% of parent width.
--   Fixes header height bug which affected `<pxb-drawer-header>` in Safari.
--   Fixes misalignment of `<pxb-info-list-item>`'s right content.
--   Fixes RTL styles in `<pxb-dropdown-toolbar>`.
--   Fixes uneven vertical alignment of icon and text in `<pxb-empty-state>` action buttons. 
--   Fixes `<pxb-user-menu>` menu header avatar offset.
--   Fixes `<pxb-drawer>` `sideBorder` prop to use `mat-elevation` class.  
+- Fixes bug in `<pxb-mobile-stepper>` which makes component span 100% of parent width.
+- Fixes header height bug which affected `<pxb-drawer-header>` in Safari.
+- Fixes misalignment of `<pxb-info-list-item>`'s right content.
+- Fixes RTL styles in `<pxb-dropdown-toolbar>`.
+- Fixes uneven vertical alignment of icon and text in `<pxb-empty-state>` action buttons.
+- Fixes `<pxb-user-menu>` menu header avatar offset.
+- Fixes `<pxb-drawer>` `sideBorder` prop to use `mat-elevation` class.
 
 ### Removed
 
--   Removes automatic RTL flip logic from user-provided icons to `<pxb-info-list-item>`.
+- Removes automatic RTL flip logic from user-provided icons to `<pxb-info-list-item>`.
 
 ### Changed
 
--   Default styles of `<pxb-dropdown-toolbar>` for more padding around the dropdown arrow.
--   Changed `<pxb-user-menu>` menu title default font size to 16px.
--   Changed `<pxb-user-menu>` menu subtitle default font size to 14px.
+- Default styles of `<pxb-dropdown-toolbar>` for more padding around the dropdown arrow.
+- Changed `<pxb-user-menu>` menu title default font size to 16px.
+- Changed `<pxb-user-menu>` menu subtitle default font size to 14px.
 
 ## v4.0.0
 
 ### Added
 
--   Added `hidden` prop to the `<pxb-drawer-nav-item>`.
--   Enhanced `<pxb-empty-state>` to allow ng-content as `title` or `description`.
+- Added `hidden` prop to the `<pxb-drawer-nav-item>`.
+- Enhanced `<pxb-empty-state>` to allow ng-content as `title` or `description`.
 
 ### Changed
 
--   Migrated to Angular 10
--   Renamed several classes and updated styles for the `<pxb-drawer>`
--   Updated default style of the `<pxb-hero>`
+- Migrated to Angular 10
+- Renamed several classes and updated styles for the `<pxb-drawer>`
+- Updated default style of the `<pxb-hero>`
 
 ## v3.0.1
 
 ### Fixed
 
--   Fixes bug in InfoListItem where divider was not working with `mat-ripple`.
--   Changes default display setting of ListItemTag so it doesn't take up 100% width in non-flex containers.
--   Updates the ListItemTag styles to match our DSM recommendations.
+- Fixes bug in InfoListItem where divider was not working with `mat-ripple`.
+- Changes default display setting of ListItemTag so it doesn't take up 100% width in non-flex containers.
+- Updates the ListItemTag styles to match our DSM recommendations.
 
 ## v3.0.0
 
 ### Added
 
--   Adds a new `rail` variant to the `<pxb-drawer-layout>`.
--   Adds a host class to each PX Blue component tag
+- Adds a new `rail` variant to the `<pxb-drawer-layout>`.
+- Adds a host class to each PX Blue component tag
 
 ### Changed
 
--   Removed right-to-left icon inverting logic per [Material Design's bidirectionality guideline](https://material.io/design/usability/bidirectionality.html#mirroring-layout).
+- Removed right-to-left icon inverting logic per [Material Design's bidirectionality guideline](https://material.io/design/usability/bidirectionality.html#mirroring-layout).
 
 ## v2.1.0
 
 ### Added
 
--   Adds new component for `<pxb-user-menu>` (use @pxblue/angular-themes v5.1.0+ to get PX Blue themes for this component).
--   Adds new component for `<pxb-dropdown-toolbar>`.
--   Adds `iconAlign` attribute to `<pxb-info-list-item>` to align icons left (default), center or right.
+- Adds new component for `<pxb-user-menu>` (use @pxblue/angular-themes v5.1.0+ to get PX Blue themes for this component).
+- Adds new component for `<pxb-dropdown-toolbar>`.
+- Adds `iconAlign` attribute to `<pxb-info-list-item>` to align icons left (default), center or right.
 
 ## v2.0.0
 
 ### Added
 
--   Adds new components for `<pxb-score-card>`, `<pxb-info-list-item>`, `<pxb-list-item-tag>`, and `<pxb-spacer>`.
--   `<pxb-channel-value>`'s value attribute now accepts both `string` type and `number` type.
--   Enables support for Angular 9+.
+- Adds new components for `<pxb-score-card>`, `<pxb-info-list-item>`, `<pxb-list-item-tag>`, and `<pxb-spacer>`.
+- `<pxb-channel-value>`'s value attribute now accepts both `string` type and `number` type.
+- Enables support for Angular 9+.
 
 ### Changed
 
--   Updates colors for accessibility
+- Updates colors for accessibility
 
-    _Breaking Changes_
+  _Breaking Changes_
 
--   We now switched to use `@pxblue/angular-themes` for our application's default style.
--   Deep imports are deprecated; access modules by importing `@pxblue/angular-components`.
--   `<pxb-empty-state>`'s attribute `empty-icon` has been renamed to `emptyIcon` to reflect the Angular convention.
--   `fontSize` attributes have been removed from `<pxb-hero>` and `<pxb-channel-value>`
-    components. Font size can be set directly through the style attribute: `[fontSize]="20"` => `style="font-size: 20px"`
--   `iconSize` attribute for `<pxb-hero>` now takes only numeric values
+- We now switched to use `@pxblue/angular-themes` for our application's default style.
+- Deep imports are deprecated; access modules by importing `@pxblue/angular-components`.
+- `<pxb-empty-state>`'s attribute `empty-icon` has been renamed to `emptyIcon` to reflect the Angular convention.
+- `fontSize` attributes have been removed from `<pxb-hero>` and `<pxb-channel-value>`
+  components. Font size can be set directly through the style attribute: `[fontSize]="20"` => `style="font-size: 20px"`
+- `iconSize` attribute for `<pxb-hero>` now takes only numeric values
 
 ## v1.3.0
 
 ### Added
 
--   Creates a storybook demo application
+- Creates a storybook demo application
 
 ### Fixed
 
--   Fixes bug in `<pxb-channel-value>` where font size input was not being used
+- Fixes bug in `<pxb-channel-value>` where font size input was not being used
 
 ## v1.2.1
 
 ### Added
 
--   Adds a new component for `<pxb-empty-state>`
--   New index file for simpler import syntax
-    -   `import {XXX} from '@pxblue/angular-components'`
+- Adds a new component for `<pxb-empty-state>`
+- New index file for simpler import syntax
+  - `import {XXX} from '@pxblue/angular-components'`
 
 ## v1.1.0
 
 ### Added
 
--   Enables support for Angular 7+
+- Enables support for Angular 7+
 
 ## v1.0.0
 
 ### Added
 
--   Angular 7-compatible components
+- Angular 7-compatible components
 
 ### Fixed
 
--   Minor styling fixes
+- Minor styling fixes
 
 ## v0.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Added
 
-- Adds new property `color` to `<pxb-dropdown-toolbar>`.
-- Adds new property `color` to `<pxb-drawer-header>`.
+- Added new property `color` to `<pxb-dropdown-toolbar>`.
+- Added new property `color` to `<pxb-drawer-header>`.
 
 ### Changed
 

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pxblue/angular-components",
-  "version": "4.2.0-beta.1",
+  "version": "4.2.0",
   "description": "Angular components for PX Blue applications",
   "scripts": {
     "ng": "ng",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "version": "0.0.0",
     "description": "Angular components for PX Blue applications",
     "main": "index.js",
+    "prettier": "@pxblue/prettier-config",
     "scripts": {
         "initialize": "bash scripts/initializeSubmodule.sh",
         "test": "cd ./components && yarn test:ci",
@@ -37,5 +38,9 @@
     "homepage": "https://github.com/pxblue/angular-component-library#readme",
     "directories": {
         "doc": "docs"
+    },
+    "devDependencies": {
+        "@pxblue/prettier-config": "^1.0.2",
+        "prettier": "^2.2.1"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,3 +2,12 @@
 # yarn lockfile v1
 
 
+"@pxblue/prettier-config@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@pxblue/prettier-config/-/prettier-config-1.0.2.tgz#fb00503df6557b66c3d91d43c9101e614c35d2ec"
+  integrity sha512-/3cLBoTjZs3kV1ATPA/Sp0tsL7XmlV/b8HW/qt0jqR/uP5+cdXL2YIhMXQngLRa7PhpSkEiRIYK5sl0rKsXTUg==
+
+prettier@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
+  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==


### PR DESCRIPTION
Update package version number to 4.2.0

*Note: prettier reformatted this changelog differently than the other repo's for some reason unknown to me. Is this intended or should I manually update this to have the same format as the other changelogs? 