### PR TITLE
Fix info list item icon alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Added new property `disabled` to `<pxb-info-list-item`>.
 
+### Fixed
+
+-   Fixed non-centered icon alignment in `<pxb-info-list-item>`.
+
 ## v4.2.0 (March 31, 2021)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## v4.2.1 (Not Published Yet)
+## v4.3.0 (April 27, 2021)
 
 ### Added
 

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pxblue/angular-components",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "Angular components for PX Blue applications",
   "scripts": {
     "ng": "ng",

--- a/components/src/core/info-list-item/info-list-item.component.scss
+++ b/components/src/core/info-list-item/info-list-item.component.scss
@@ -130,6 +130,7 @@ $denseHeight: 3.25rem;
         width: 2.5rem;
         min-width: 2.5rem;
         max-width: 40px;
+        line-height: 1.5rem;
         height: auto; /* Used to override height applied when wrapped in a mat-list. */
         margin-right: 16px;
         padding: 0;


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #252 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Fix info list item icon mis-alignment; it's now centered

Hosted here: 
https://pxblue-angular-library.web.app/