### PR TITLE
Remove inline icon color from info-list-item with icon story

### DIFF
--- a/demos/storybook/stories/info-list-item/with-icon.stories.ts
+++ b/demos/storybook/stories/info-list-item/with-icon.stories.ts
@@ -6,7 +6,7 @@ export const withIcon = (): any => ({
         <pxb-info-list-item [iconAlign]="iconAlign">
             <span pxb-title>Info List Item</span>
             <span pxb-subtitle>with an icon</span>
-            <mat-icon [style.color]="colors.black[500]" pxb-icon>alarm</mat-icon>
+            <mat-icon pxb-icon>alarm</mat-icon>
         </pxb-info-list-item>
       `,
     props: {


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #259.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Remove inline icon color from info-list-item with icon story

#### Screenshots:
![Screen Shot 2021-05-03 at 1 06 04 PM](https://user-images.githubusercontent.com/13989985/116908220-a1dcfa00-ac10-11eb-8966-e05ec41116dd.png)
![Screen Shot 2021-05-03 at 1 06 11 PM](https://user-images.githubusercontent.com/13989985/116908230-a43f5400-ac10-11eb-9b51-e9f39f734070.png)
