### PR TITLE
Add new prop to disable tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v4.4.0 (not published yet)
 
+### Added
+
+-   Added `disableRailTooltip` prop to `<pxb-drawer>`.
+
 ### Fixed
 
 -   Fixed non-centered `<pxb-list-item-tag>` text.

--- a/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.ts
+++ b/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.ts
@@ -96,7 +96,7 @@ export type ActiveItemBackgroundShape = 'round' | 'square';
                     <div
                         (click)="selectItem()"
                         class="pxb-drawer-nav-item-rail"
-                        [matTooltip]="title"
+                        [matTooltip]="showTooltipOnRailHover() ? title : ''"
                         [matTooltipDisabled]="!isRailCondensed()"
                         matTooltipPosition="right"
                     >
@@ -184,6 +184,10 @@ export class DrawerNavItemComponent extends StateListener implements Omit<Drawer
 
     isRailCondensed(): boolean {
         return this.drawerService.isRailCondensed();
+    }
+
+    showTooltipOnRailHover(): boolean {
+        return this.drawerService.isShowTooltipOnRailHover();
     }
 
     manageActiveItemTreeHighlight(): void {

--- a/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.ts
+++ b/components/src/core/drawer/drawer-body/nav-item/drawer-nav-item.component.ts
@@ -187,7 +187,7 @@ export class DrawerNavItemComponent extends StateListener implements Omit<Drawer
     }
 
     showTooltipOnRailHover(): boolean {
-        return this.drawerService.isShowTooltipOnRailHover();
+        return !this.drawerService.isDisableRailTooltip();
     }
 
     manageActiveItemTreeHighlight(): void {

--- a/components/src/core/drawer/drawer.component.ts
+++ b/components/src/core/drawer/drawer.component.ts
@@ -45,7 +45,7 @@ export class DrawerComponent extends StateListener implements OnInit, OnChanges 
     @Input() disableActiveItemParentStyles = false;
     @Input() openOnRailHover = true;
     @Input() openOnRailHoverDelay = 500;
-    @Input() showTooltipOnRailHover = true;
+    @Input() disableRailTooltip = false;
 
     hoverDelayTimeout: any;
     drawerSelectionListener: Subscription;
@@ -65,7 +65,7 @@ export class DrawerComponent extends StateListener implements OnInit, OnChanges 
         this.drawerService.setSideBorder(this.sideBorder);
         this.drawerService.setDrawerOpen(this.open);
         this.drawerService.setIsCondensed(this.condensed);
-        this.drawerService.setShowTooltipOnRailHover(this.showTooltipOnRailHover);
+        this.drawerService.setDisableRailTooltip(this.disableRailTooltip);
         this.drawerService.setDisableActiveItemParentStyles(this.disableActiveItemParentStyles);
     }
 

--- a/components/src/core/drawer/drawer.component.ts
+++ b/components/src/core/drawer/drawer.component.ts
@@ -43,8 +43,9 @@ export class DrawerComponent extends StateListener implements OnInit, OnChanges 
     @Input() condensed = false;
     @Input() sideBorder = false;
     @Input() disableActiveItemParentStyles = false;
-    @Input() openOnHover = true;
-    @Input() openOnHoverDelay = 500;
+    @Input() openOnRailHover = true;
+    @Input() openOnRailHoverDelay = 500;
+    @Input() showTooltipOnRailHover = true;
 
     hoverDelayTimeout: any;
     drawerSelectionListener: Subscription;
@@ -64,20 +65,21 @@ export class DrawerComponent extends StateListener implements OnInit, OnChanges 
         this.drawerService.setSideBorder(this.sideBorder);
         this.drawerService.setDrawerOpen(this.open);
         this.drawerService.setIsCondensed(this.condensed);
+        this.drawerService.setShowTooltipOnRailHover(this.showTooltipOnRailHover);
         this.drawerService.setDisableActiveItemParentStyles(this.disableActiveItemParentStyles);
     }
 
     hoverDrawer(): void {
-        if (!this.open && this.openOnHover) {
+        if (!this.open && this.openOnRailHover) {
             this.hoverDelayTimeout = setTimeout(() => {
                 this.drawerService.setDrawerTempOpen(true);
                 this.changeDetector.detectChanges();
-            }, this.openOnHoverDelay);
+            }, this.openOnRailHoverDelay);
         }
     }
 
     unhoverDrawer(): void {
-        if (this.openOnHover) {
+        if (this.openOnRailHover) {
             clearTimeout(this.hoverDelayTimeout);
             if (this.drawerService.isTempOpen()) {
                 this.drawerService.setDrawerTempOpen(false);

--- a/components/src/core/drawer/service/drawer.service.ts
+++ b/components/src/core/drawer/service/drawer.service.ts
@@ -13,7 +13,7 @@ export class DrawerService {
     private tempOpen = false;
     private isCondensed: boolean;
     private sideBorder: boolean;
-    private showTooltipOnRailHover: boolean
+    private showTooltipOnRailHover: boolean;
 
     drawerOpenObs = new Subject<boolean>();
     drawerSelectObs = new Subject<boolean>();

--- a/components/src/core/drawer/service/drawer.service.ts
+++ b/components/src/core/drawer/service/drawer.service.ts
@@ -13,7 +13,7 @@ export class DrawerService {
     private tempOpen = false;
     private isCondensed: boolean;
     private sideBorder: boolean;
-    private showTooltipOnRailHover: boolean;
+    private disableRailTooltip: boolean;
 
     drawerOpenObs = new Subject<boolean>();
     drawerSelectObs = new Subject<boolean>();
@@ -49,12 +49,12 @@ export class DrawerService {
         this.drawerOpenObs.next(this.isDrawerOpen());
     }
 
-    setShowTooltipOnRailHover(showTooltip: boolean): void {
-        this.showTooltipOnRailHover = showTooltip;
+    setDisableRailTooltip(disableRailTooltip: boolean): void {
+        this.disableRailTooltip = disableRailTooltip;
     }
 
-    isShowTooltipOnRailHover(): boolean {
-        return this.showTooltipOnRailHover;
+    isDisableRailTooltip(): boolean {
+        return this.disableRailTooltip;
     }
 
     setDrawerVariant(variant: DrawerLayoutVariantType): void {

--- a/components/src/core/drawer/service/drawer.service.ts
+++ b/components/src/core/drawer/service/drawer.service.ts
@@ -13,6 +13,7 @@ export class DrawerService {
     private tempOpen = false;
     private isCondensed: boolean;
     private sideBorder: boolean;
+    private showTooltipOnRailHover: boolean
 
     drawerOpenObs = new Subject<boolean>();
     drawerSelectObs = new Subject<boolean>();
@@ -46,6 +47,14 @@ export class DrawerService {
     setDrawerOpen(drawerOpen: boolean): void {
         this.drawerOpen = drawerOpen;
         this.drawerOpenObs.next(this.isDrawerOpen());
+    }
+
+    setShowTooltipOnRailHover(showTooltip: boolean): void {
+        this.showTooltipOnRailHover = showTooltip;
+    }
+
+    isShowTooltipOnRailHover(): boolean {
+        return this.showTooltipOnRailHover;
     }
 
     setDrawerVariant(variant: DrawerLayoutVariantType): void {

--- a/demos/storybook/stories/drawer/within-drawer-layout-rail.stories.ts
+++ b/demos/storybook/stories/drawer/within-drawer-layout-rail.stories.ts
@@ -24,7 +24,8 @@ export const withinDrawerLayoutRail = (): any => ({
     ],
     template: `
         <pxb-drawer-layout [dir]="direction()" variant="rail" (backdropClick)="state.open = false">
-            <pxb-drawer pxb-drawer [open]="state.open" [sideBorder]="sideBorder" [condensed]="condensed">
+            <pxb-drawer pxb-drawer [open]="state.open" [sideBorder]="sideBorder"
+               [condensed]="condensed" [showTooltipOnRailHover]="showTooltipOnRailHover">
                <pxb-drawer-body>
                   <pxb-drawer-nav-group>
                      <pxb-drawer-nav-item *ngFor="let navItem of navItems"
@@ -71,5 +72,6 @@ export const withinDrawerLayoutRail = (): any => ({
         },
         condensed: boolean('condensed', true),
         divider: boolean('divider', false),
+        showTooltipOnRailHover: boolean('showTooltipOnRailHover', true)
     },
 });

--- a/demos/storybook/stories/drawer/within-drawer-layout-rail.stories.ts
+++ b/demos/storybook/stories/drawer/within-drawer-layout-rail.stories.ts
@@ -25,7 +25,7 @@ export const withinDrawerLayoutRail = (): any => ({
     template: `
         <pxb-drawer-layout [dir]="direction()" variant="rail" (backdropClick)="state.open = false">
             <pxb-drawer pxb-drawer [open]="state.open" [sideBorder]="sideBorder"
-               [condensed]="condensed" [showTooltipOnRailHover]="showTooltipOnRailHover">
+               [condensed]="condensed" [disableRailTooltip]="disableRailTooltip">
                <pxb-drawer-body>
                   <pxb-drawer-nav-group>
                      <pxb-drawer-nav-item *ngFor="let navItem of navItems"
@@ -72,6 +72,6 @@ export const withinDrawerLayoutRail = (): any => ({
         },
         condensed: boolean('condensed', true),
         divider: boolean('divider', false),
-        showTooltipOnRailHover: boolean('showTooltipOnRailHover', true),
+        disableRailTooltip: boolean('disableRailTooltip', false),
     },
 });

--- a/demos/storybook/stories/drawer/within-drawer-layout-rail.stories.ts
+++ b/demos/storybook/stories/drawer/within-drawer-layout-rail.stories.ts
@@ -72,6 +72,6 @@ export const withinDrawerLayoutRail = (): any => ({
         },
         condensed: boolean('condensed', true),
         divider: boolean('divider', false),
-        showTooltipOnRailHover: boolean('showTooltipOnRailHover', true)
+        showTooltipOnRailHover: boolean('showTooltipOnRailHover', true),
     },
 });

--- a/docs/Drawer.md
+++ b/docs/Drawer.md
@@ -26,7 +26,7 @@ Parent element (`<pxb-drawer>`) attributes:
 | @Input                        | Description                                                                            | Type      | Required | Default |
 | ----------------------------- | -------------------------------------------------------------------------------------- | --------- | -------- | ------- |
 | condensed                     | Skinny view for `rail` variant                                                         | `boolean` | no       | false   |
-| showTooltipOnRailHover        | Show tooltips on hover for the `rail` variant                                          | `boolean` | no       | true    |
+| disableRailTooltip            | Show tooltips on hover for the `rail` variant                                          | `boolean` | no       | false   |
 | disableActiveItemParentStyles | If true, NavItems will not have a bold title when a child NavItem is selected          | `boolean` | no       | false   |
 | openOnHover                   | Automatically open the drawer on hover when closed (persistent variant only)           | `boolean` | no       | true    |
 | open                          | State for the drawer                                                                   | `boolean` | yes      |         |

--- a/docs/Drawer.md
+++ b/docs/Drawer.md
@@ -26,6 +26,7 @@ Parent element (`<pxb-drawer>`) attributes:
 | @Input                        | Description                                                                            | Type      | Required | Default |
 | ----------------------------- | -------------------------------------------------------------------------------------- | --------- | -------- | ------- |
 | condensed                     | Skinny view for `rail` variant                                                         | `boolean` | no       | false   |
+| showTooltipOnRailHover        | Show tooltips on hover for the `rail` variant                                          | `boolean` | no       | true    |
 | disableActiveItemParentStyles | If true, NavItems will not have a bold title when a child NavItem is selected          | `boolean` | no       | false   |
 | openOnHover                   | Automatically open the drawer on hover when closed (persistent variant only)           | `boolean` | no       | true    |
 | open                          | State for the drawer                                                                   | `boolean` | yes      |         |


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #268 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Add prop to enable the default tooltip hover for rail

What is the naming convention we want to do here for prop names? 
