### PR TITLE
Feature/drawer header no menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixed
 
-- Fixed `<pxb-drawer-header>` content alignment when a menu icon is not provided.
+- Fixed `<pxb-drawer-header>` content alignment when omitting a menu icon.
 
 ## v4.4.0 (May 28, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Added `<pxb-app-bar>` component.
 - Added `wrapInfo` prop to `<pxb-info-list-item>`.
 
+### Fixed
+
+- Fixed `<pxb-drawer-header>` content alignment when a menu icon is not provided.
+
 ## v4.4.0 (May 28, 2021)
 
 ### Changed

--- a/components/src/core/drawer/drawer-header/drawer-header.component.scss
+++ b/components/src/core/drawer/drawer-header/drawer-header.component.scss
@@ -57,9 +57,14 @@
         margin-left: -0.5rem;
         width: 2.5rem;
         @include scale-icon-button();
+        &:empty {
+            width: 0;
+            margin: 0;
+        }
     }
     &.pxb-drawer-header-no-icon .pxb-drawer-header-icon-wrapper {
-        margin-right: 0;
+        width: 0;
+        margin: 0;
     }
 
     .pxb-drawer-header-title-wrapper {

--- a/demos/storybook/stories/drawer/with-custom-header.stories.ts
+++ b/demos/storybook/stories/drawer/with-custom-header.stories.ts
@@ -1,4 +1,5 @@
 import { navItems } from './basic-config.stories';
+import {boolean} from "@storybook/addon-knobs";
 
 const bgImage = require('../../assets/farm.jpg');
 
@@ -22,7 +23,7 @@ export const withCustomHeader = (): any => ({
     template: `
         <pxb-drawer [open]="state.open">
           <pxb-drawer-header>
-            <button pxb-icon mat-icon-button (click)="toggleDrawer(state)">
+            <button *ngIf="!hideMenuIcon" pxb-icon mat-icon-button (click)="toggleDrawer(state)">
                 <mat-icon>menu</mat-icon>
             </button>
             <div pxb-title-content *ngIf="state.open" class="header-content">
@@ -47,5 +48,6 @@ export const withCustomHeader = (): any => ({
       `,
     props: {
         navItems: navItems,
+        hideMenuIcon: boolean('Hide Menu Icon', false)
     },
 });

--- a/demos/storybook/stories/drawer/with-custom-header.stories.ts
+++ b/demos/storybook/stories/drawer/with-custom-header.stories.ts
@@ -1,5 +1,5 @@
 import { navItems } from './basic-config.stories';
-import {boolean} from "@storybook/addon-knobs";
+import { boolean } from '@storybook/addon-knobs';
 
 const bgImage = require('../../assets/farm.jpg');
 
@@ -48,6 +48,6 @@ export const withCustomHeader = (): any => ({
       `,
     props: {
         navItems: navItems,
-        hideMenuIcon: boolean('Hide Menu Icon', false)
+        hideMenuIcon: boolean('Hide Menu Icon', false),
     },
 });


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #277 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Fix header styles when there is no drawer menu icon provided.  Testable through a new knob. 

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- https://pxb-storybook-ng-feature.web.app/?path=/story/components-drawer--with-custom-header
