### PR TITLE
Fix mobile stepper button uneven width spacing issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Change Log
 
 ## v6.0.0 (Unreleased)
+
 ### Added
+
 -   Added new property `unitSpace` to `<pxb-channel-value>` to manage spacing between the value and units.
+
+### Fixed
+
+-   Fixed stepper spacing in `<pxb-mobile-stepper` when Back and Next buttons are uneven width.  
+
 ## v5.0.1 (July 30, 2021)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
--   Fixed stepper spacing in `<pxb-mobile-stepper` when Back and Next buttons are uneven width.  
+-   Fixed stepper spacing in `<pxb-mobile-stepper>` when Back and Next buttons are uneven width.  
 
 ## v5.0.1 (July 30, 2021)
 

--- a/components/src/core/mobile-stepper/mobile-stepper.component.html
+++ b/components/src/core/mobile-stepper/mobile-stepper.component.html
@@ -1,5 +1,7 @@
 <div class="pxb-mobile-stepper-content">
-    <ng-content select="[pxb-back-button]"></ng-content>
+    <div class="pxb-mobile-stepper-back-button-wrapper">
+        <ng-content select="[pxb-back-button]"></ng-content>
+    </div>
     <div *ngIf="variant === 'dots'" class="pxb-mobile-stepper-dots">
         <div
             *ngFor="let step of stepsArray; let index = index"
@@ -11,5 +13,8 @@
     </div>
     <div *ngIf="variant === 'text'" class="mat-subheading-2">{{ activeStep + 1 }} / {{ stepsArray.length }}</div>
     <mat-progress-bar *ngIf="variant === 'progress'" mode="determinate" [value]="getProgressFill()"></mat-progress-bar>
-    <ng-content select="[pxb-next-button]"></ng-content>
+
+    <div class="pxb-mobile-stepper-next-button-wrapper">
+        <ng-content select="[pxb-next-button]"></ng-content>
+    </div>
 </div>

--- a/components/src/core/mobile-stepper/mobile-stepper.component.scss
+++ b/components/src/core/mobile-stepper/mobile-stepper.component.scss
@@ -33,3 +33,16 @@
 .pxb-mobile-stepper-display-none {
     display: none;
 }
+
+.pxb-mobile-stepper-next-button-wrapper,
+.pxb-mobile-stepper-back-button-wrapper {
+    display: flex;
+    flex: 1;
+}
+
+.pxb-mobile-stepper-next-button-wrapper {
+    justify-content: end;
+}
+.pxb-mobile-stepper-back-button-wrapper {
+    justify-content: start;
+}

--- a/components/src/core/mobile-stepper/mobile-stepper.component.spec.ts
+++ b/components/src/core/mobile-stepper/mobile-stepper.component.spec.ts
@@ -54,6 +54,8 @@ describe('DotStepperComponent', () => {
             '.pxb-mobile-stepper-content',
             '.pxb-mobile-stepper-dots',
             '.pxb-mobile-stepper-dot-active',
+            '.pxb-mobile-stepper-next-button-wrapper',
+            '.pxb-mobile-stepper-back-button-wrapper',
         ];
         for (const className of classList) {
             count(fixture, className);

--- a/demos/storybook/stories/mobile-stepper/with-full-config.stories.ts
+++ b/demos/storybook/stories/mobile-stepper/with-full-config.stories.ts
@@ -1,4 +1,4 @@
-import {boolean, number, select, text} from '@storybook/addon-knobs';
+import { boolean, number, select, text } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 
 export const withFullConfig = (): any => ({

--- a/demos/storybook/stories/mobile-stepper/with-full-config.stories.ts
+++ b/demos/storybook/stories/mobile-stepper/with-full-config.stories.ts
@@ -1,4 +1,4 @@
-import { boolean, number, select } from '@storybook/addon-knobs';
+import {boolean, number, select, text} from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 
 export const withFullConfig = (): any => ({
@@ -22,11 +22,11 @@ export const withFullConfig = (): any => ({
             <button pxb-back-button mat-stroked-button color="primary" 
                 [style.visibility]="showBackButton ? 'visible' : 'hidden' "
                 [disabled]="activeStep === 0" 
-                (click)="activeStep = activeStep - 1; goBack();">Back</button>
+                (click)="activeStep = activeStep - 1; goBack();">{{ backButtonText }} </button>
             <button pxb-next-button mat-flat-button color="primary" 
                 [style.visibility]="showNextButton ? 'visible' : 'hidden' "
                 [disabled]="activeStep === steps - 1" 
-                (click)="activeStep = activeStep + 1; goNext();"> Next</button>
+                (click)="activeStep = activeStep + 1; goNext();"> {{ nextButtonText }} </button>
          </pxb-mobile-stepper>
      </div>
     `,
@@ -39,5 +39,7 @@ export const withFullConfig = (): any => ({
         goNext: action('Next Button Clicked'),
         showBackButton: boolean('Show Back Button', true),
         showNextButton: boolean('Show Next Button', true),
+        backButtonText: text('Back Button Text', 'Back'),
+        nextButtonText: text('Next Button Text', 'Next'),
     },
 });

--- a/docs/MobileStepper.md
+++ b/docs/MobileStepper.md
@@ -74,12 +74,14 @@ The following child elements are projected into `<pxb-mobile-stepper>`:
 
 Each PX Blue component has classes which can be used to override component styles:
 
-| Name                             | Description                                            |
-| -------------------------------- | ------------------------------------------------------ |
-| pxb-mobile-stepper               | Styles applied to the tag                              |
-| pxb-mobile-stepper-content       | Styles applied to the mobile stepper container         |
-| pxb-mobile-stepper-dots          | Styles applied to the mobile stepper dots container    |
-| pxb-mobile-stepper-dot           | Styles applied to each dot in the stepper              |
-| pxb-mobile-stepper-dot-active    | Styles applied to the dot representing the active step |
-| pxb-mobile-stepper-dot-visited   | Styles applied to the visited dots                     |
-| pxb-mobile-stepper-dot-unvisited | Styles applied to the dots that were not visited yet   |
+| Name                                        | Description                                            |
+| ------------------------------------------- | ------------------------------------------------------ |
+| pxb-mobile-stepper                          | Styles applied to the tag                              |
+| pxb-mobile-stepper-content                  | Styles applied to the mobile stepper container         |
+| pxb-mobile-stepper-dots                     | Styles applied to the mobile stepper dots container    |
+| pxb-mobile-stepper-dot                      | Styles applied to each dot in the stepper              |
+| pxb-mobile-stepper-dot-active               | Styles applied to the dot representing the active step |
+| pxb-mobile-stepper-dot-visited              | Styles applied to the visited dots                     |
+| pxb-mobile-stepper-dot-unvisited            | Styles applied to the dots that were not visited yet   |
+|pxb-mobile-stepper-next-button-wrapper       | Styles applied to the next button wrapper              | 
+|pxb-mobile-stepper-back-button-wrapper       | Styles applied to the back button wrapper              | 

--- a/docs/MobileStepper.md
+++ b/docs/MobileStepper.md
@@ -53,11 +53,11 @@ Parent element (`<pxb-mobile-stepper`) attributes:
 
 <div style="overflow: auto;">
 
-| @Input     | Description                        | Type     | Required | Default    |     |        |
-| ---------- | ---------------------------------- | -------- | -------- | ---------- | --- | ------ |
-| activeStep | The index of the active step       | `number` | yes      |            |     |        |
-| steps      | Total number of steps to display   | `number` | yes      |            |     |        |  
-| variant    | Which type of indicator to use     | `dots    | text     | progress ` | no  | `dots` |
+| @Input     | Description                        | Type     | Required | Default    | 
+| ---------- | ---------------------------------- | -------- | -------- | ---------- | 
+| activeStep | The index of the active step       | `number` | yes      |            |  
+| steps      | Total number of steps to display   | `number` | yes      |            | 
+| variant    | Which type of indicator to use     | `dots`   | no       | `progress` |
 
 </div>
 


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #332 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Adds more customization options to the full-config mobile stepper example.
- Ensures that the stepper progress indicator stays centered regardless of  back/next button uneven width.

Check it out here: https://pxb-storybook-ng-feature.web.app/?path=/story/components-mobile-stepper--with-full-config