### PR TITLE
Bug/337 app bar support class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 -   Fixed stepper spacing in `<pxb-mobile-stepper>` when Back and Next buttons are uneven width.  
+-   Fixed bug in `<pxb-app-bar>` that prevented class overrides on the root element.
 
 ## v5.0.1 (July 30, 2021)
 

--- a/components/src/core/app-bar/app-bar.component.spec.ts
+++ b/components/src/core/app-bar/app-bar.component.spec.ts
@@ -33,6 +33,8 @@ describe('AppBarComponent', () => {
     it('should enforce class naming conventions', () => {
         fixture.detectChanges();
         const classList = [
+            '.pxb-app-bar',
+            '.mat-elevation-z4',
             '.pxb-app-bar-content',
             '.pxb-app-bar-background',
             '.pxb-app-bar-collapsed',

--- a/components/src/core/app-bar/app-bar.component.ts
+++ b/components/src/core/app-bar/app-bar.component.ts
@@ -102,8 +102,7 @@ export class AppBarComponent implements OnInit, AfterViewInit, OnChanges, OnDest
 
     contentSize = 0;
 
-    constructor(private readonly _ref: ChangeDetectorRef) {
-    }
+    constructor(private readonly _ref: ChangeDetectorRef) {}
 
     ngOnInit(): void {
         if (!this.scrollThreshold) {

--- a/components/src/core/app-bar/app-bar.component.ts
+++ b/components/src/core/app-bar/app-bar.component.ts
@@ -4,7 +4,6 @@ import {
     ChangeDetectorRef,
     Component,
     EventEmitter,
-    HostBinding,
     Input,
     OnChanges,
     OnDestroy,
@@ -28,6 +27,9 @@ import { Element } from '@angular/compiler';
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     styleUrls: ['./app-bar.component.scss'],
+    host: {
+        class: 'pxb-app-bar mat-elevation-z4',
+    },
     template: `
         <mat-toolbar
             [color]="color"
@@ -87,8 +89,6 @@ export class AppBarComponent implements OnInit, AfterViewInit, OnChanges, OnDest
     /** Event emitter for when the appbar opens or closes.  Emits a boolean that indicates whether the AppBar is expanded. */
     @Output() collapsedChange: EventEmitter<boolean> = new EventEmitter();
 
-    @HostBinding('class') @Input('class') classList = 'pxb-app-bar mat-elevation-z4';
-
     scrollEl;
 
     isCollapsed = false;
@@ -102,7 +102,8 @@ export class AppBarComponent implements OnInit, AfterViewInit, OnChanges, OnDest
 
     contentSize = 0;
 
-    constructor(private readonly _ref: ChangeDetectorRef) {}
+    constructor(private readonly _ref: ChangeDetectorRef) {
+    }
 
     ngOnInit(): void {
         if (!this.scrollThreshold) {


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #337

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- I'm not sure why we used @HostBinding in the first place here; maybe it was because we needed to assign 2 classes to the root instead of one.  I'm replaced the @HostBinding with the same `host` attribute that we've used on all other components & it seems to be working fine. 
- Tested in angular-design-patterns repo, user-provided classes no longer break the styles and are appended to the end of the root element's `classList`. 
