### PR TITLE
Feature/empty state example

### DIFF
--- a/demos/storybook/stories/empty-state/_module.stories.ts
+++ b/demos/storybook/stories/empty-state/_module.stories.ts
@@ -15,7 +15,10 @@ import { withDescription } from './with-description.stories';
 import { withBasicConfig } from './basic-config.stories';
 import { withActions } from './with-actions.stories';
 import { withFullConfig } from './with-full-config.stories';
+import { withinACardConfig } from './within-a-card.stories';
 import { withA11y } from '@storybook/addon-a11y';
+import { MatExpansionModule } from '@angular/material/expansion';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import * as Colors from '@pxblue/colors';
 
 export const useWhiteBackground = () => (storyFn: any): any => {
@@ -41,7 +44,7 @@ export const useWhiteBackground = () => (storyFn: any): any => {
 storiesOf(`${COMPONENT_SECTION_NAME}/Empty State`, module)
     .addDecorator(
         moduleMetadata({
-            imports: [EmptyStateModule, MatButtonModule, MatIconModule, UtilModule],
+            imports: [BrowserAnimationsModule, EmptyStateModule, MatButtonModule, MatIconModule, UtilModule, MatExpansionModule],
         })
     )
     .addDecorator(withKnobs)
@@ -57,4 +60,5 @@ storiesOf(`${COMPONENT_SECTION_NAME}/Empty State`, module)
     .add(WITH_MIN_PROPS_STORY_NAME, withBasicConfig)
     .add('with description', withDescription)
     .add('with actions', withActions)
-    .add(WITH_FULL_CONFIG_STORY_NAME, withFullConfig);
+    .add(WITH_FULL_CONFIG_STORY_NAME, withFullConfig)
+    .add('within a card', withinACardConfig);

--- a/demos/storybook/stories/empty-state/_module.stories.ts
+++ b/demos/storybook/stories/empty-state/_module.stories.ts
@@ -44,7 +44,14 @@ export const useWhiteBackground = () => (storyFn: any): any => {
 storiesOf(`${COMPONENT_SECTION_NAME}/Empty State`, module)
     .addDecorator(
         moduleMetadata({
-            imports: [BrowserAnimationsModule, EmptyStateModule, MatButtonModule, MatIconModule, UtilModule, MatExpansionModule],
+            imports: [
+                BrowserAnimationsModule,
+                EmptyStateModule,
+                MatButtonModule,
+                MatIconModule,
+                UtilModule,
+                MatExpansionModule,
+            ],
         })
     )
     .addDecorator(withKnobs)

--- a/demos/storybook/stories/empty-state/within-a-card.stories.ts
+++ b/demos/storybook/stories/empty-state/within-a-card.stories.ts
@@ -6,9 +6,9 @@ import { getDirection } from '@pxblue/storybook-rtl-addon';
 export const withinACardConfig = (): any => ({
     template: `
         <mat-accordion>
-            <mat-expansion-panel [expanded]="true" style="width: 392px;">
+            <mat-expansion-panel [expanded]="true" [style.width.px]="392">
                 <mat-expansion-panel-header style="border-bottom: 1px solid #d5d8da; border-radius: 0;">
-                    <mat-panel-title style="color:#007BC1;">
+                    <mat-panel-title [style.color]="colors.blue[500]">
                         Device Usage
                     </mat-panel-title>
                 </mat-expansion-panel-header>

--- a/demos/storybook/stories/empty-state/within-a-card.stories.ts
+++ b/demos/storybook/stories/empty-state/within-a-card.stories.ts
@@ -1,7 +1,8 @@
 import { action } from '@storybook/addon-actions';
 import * as Colors from '@pxblue/colors';
 import { invertRTL } from '../../src/utils';
-const iconColor = Colors.gray[500];
+import { getDirection } from '@pxblue/storybook-rtl-addon';
+
 export const withinACardConfig = (): any => ({
     template: `
         <mat-accordion>
@@ -17,7 +18,7 @@ export const withinACardConfig = (): any => ({
                     [style.margin.px]="24"
                 >
                     <mat-icon pxb-empty-icon
-                        [style.color]="iconColor"
+                        [style.color]="colors.gray[500]"
                         [style.fontSize.px]="100"
                         [style.transform]="invertRTL()"
                     >
@@ -25,10 +26,9 @@ export const withinACardConfig = (): any => ({
                     </mat-icon>
                     <button pxb-actions mat-flat-button color="primary" (click)="click()">
                         <mat-icon 
-                            style="font-size: 16px;
-                            height: 16px;
-                            width: 16px;
-                            margin-right: 8px;"
+                            style="height: 16px; width: 16px; font-size: 16px;"
+                            [style.marginRight.px]="direction() === 'rtl' ? -4 : 8"
+                            [style.marginLeft.px]="direction() === 'rtl' ? 8 : -4"
                         >
                             add
                         </mat-icon>
@@ -41,5 +41,7 @@ export const withinACardConfig = (): any => ({
     props: {
         click: action('button clicked'),
         invertRTL: invertRTL,
+        direction: getDirection,
+        colors: Colors,
     },
 });

--- a/demos/storybook/stories/empty-state/within-a-card.stories.ts
+++ b/demos/storybook/stories/empty-state/within-a-card.stories.ts
@@ -1,0 +1,45 @@
+import { color, number, text } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
+import * as Colors from '@pxblue/colors';
+import { invertRTL } from '../../src/utils';
+
+export const withinACardConfig = (): any => ({
+    template: `
+        <mat-accordion>
+            <mat-expansion-panel (opened)="updateState(state, false)" (closed)="updateState(state, true)"  style="width: 394px">
+                <mat-expansion-panel-header>
+                    <mat-panel-title style="color:#007BC1;">
+                        Device Usage
+                    </mat-panel-title>
+                </mat-expansion-panel-header>
+                <pxb-empty-state [title]="title" [description]="description">
+                    <mat-icon pxb-empty-icon [style.color]="color" [style.fontSize.px]="fontSize"
+                        [style.transform]="invertRTL()">
+                        help_outline</mat-icon>
+                    <button pxb-actions mat-flat-button color="primary" (click)="click()">
+                        <mat-icon style="font-size: 16px;
+                        height: 16px;
+                        width: 15px;
+                        margin-right: 8px;">add</mat-icon>
+                        {{actionText}}
+                    </button>
+                </pxb-empty-state>
+            </mat-expansion-panel>
+        </mat-accordion>
+    `,
+    props: {
+        title: text('title', 'No Devices Found'),
+        description: text('description', 'After you add devices to this repository, we will show your recent device activities here.'),
+        click: action('button clicked'),
+        actionText: text('Action Text', 'Learn More'),
+        color: color('emptyIcon.color', Colors.gray[500]),
+        fontSize: number('emptyIcon.fontSize.px', 100),
+        invertRTL: invertRTL,
+        updateState: (state, val): void => {
+            state.panelOpenState = val;
+        },
+        state: {
+            panelOpenState: false,
+        },
+    },
+});

--- a/demos/storybook/stories/empty-state/within-a-card.stories.ts
+++ b/demos/storybook/stories/empty-state/within-a-card.stories.ts
@@ -1,4 +1,3 @@
-import { color, number, text } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import * as Colors from '@pxblue/colors';
 import { invertRTL } from '../../src/utils';
@@ -6,21 +5,33 @@ const iconColor = Colors.gray[500];
 export const withinACardConfig = (): any => ({
     template: `
         <mat-accordion>
-            <mat-expansion-panel (opened)="updateState(state, false)" (closed)="updateState(state, true)"  style="width: 394px">
-                <mat-expansion-panel-header>
+            <mat-expansion-panel [expanded]="true" style="width: 392px;">
+                <mat-expansion-panel-header style="border-bottom: 1px solid #d5d8da; border-radius: 0;">
                     <mat-panel-title style="color:#007BC1;">
                         Device Usage
                     </mat-panel-title>
                 </mat-expansion-panel-header>
-                <pxb-empty-state title="No Devices Found" description="After you add devices to this repository, we will show your recent device activities here.">
-                    <mat-icon pxb-empty-icon [style.color]="iconColor" [style.fontSize.px]="100"
-                        [style.transform]="invertRTL()">
-                        help_outline</mat-icon>
+                <pxb-empty-state 
+                    title="No Devices Found"
+                    description="After you add devices to this repository, we will show your recent device activities here."
+                    [style.margin.px]="24"
+                >
+                    <mat-icon pxb-empty-icon
+                        [style.color]="iconColor"
+                        [style.fontSize.px]="100"
+                        [style.transform]="invertRTL()"
+                    >
+                        help_outline
+                    </mat-icon>
                     <button pxb-actions mat-flat-button color="primary" (click)="click()">
-                        <mat-icon style="font-size: 16px;
-                        height: 16px;
-                        width: 15px;
-                        margin-right: 8px;">add</mat-icon>
+                        <mat-icon 
+                            style="font-size: 16px;
+                            height: 16px;
+                            width: 16px;
+                            margin-right: 8px;"
+                        >
+                            add
+                        </mat-icon>
                         Learn More
                     </button>
                 </pxb-empty-state>
@@ -30,11 +41,5 @@ export const withinACardConfig = (): any => ({
     props: {
         click: action('button clicked'),
         invertRTL: invertRTL,
-        updateState: (state, val): void => {
-            state.panelOpenState = val;
-        },
-        state: {
-            panelOpenState: false,
-        },
     },
 });

--- a/demos/storybook/stories/empty-state/within-a-card.stories.ts
+++ b/demos/storybook/stories/empty-state/within-a-card.stories.ts
@@ -2,7 +2,7 @@ import { color, number, text } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import * as Colors from '@pxblue/colors';
 import { invertRTL } from '../../src/utils';
-
+const iconColor = Colors.gray[500];
 export const withinACardConfig = (): any => ({
     template: `
         <mat-accordion>
@@ -12,8 +12,8 @@ export const withinACardConfig = (): any => ({
                         Device Usage
                     </mat-panel-title>
                 </mat-expansion-panel-header>
-                <pxb-empty-state [title]="title" [description]="description">
-                    <mat-icon pxb-empty-icon [style.color]="color" [style.fontSize.px]="fontSize"
+                <pxb-empty-state title="No Devices Found" description="After you add devices to this repository, we will show your recent device activities here.">
+                    <mat-icon pxb-empty-icon [style.color]="iconColor" [style.fontSize.px]="100"
                         [style.transform]="invertRTL()">
                         help_outline</mat-icon>
                     <button pxb-actions mat-flat-button color="primary" (click)="click()">
@@ -21,19 +21,14 @@ export const withinACardConfig = (): any => ({
                         height: 16px;
                         width: 15px;
                         margin-right: 8px;">add</mat-icon>
-                        {{actionText}}
+                        Learn More
                     </button>
                 </pxb-empty-state>
             </mat-expansion-panel>
         </mat-accordion>
     `,
     props: {
-        title: text('title', 'No Devices Found'),
-        description: text('description', 'After you add devices to this repository, we will show your recent device activities here.'),
         click: action('button clicked'),
-        actionText: text('Action Text', 'Learn More'),
-        color: color('emptyIcon.color', Colors.gray[500]),
-        fontSize: number('emptyIcon.fontSize.px', 100),
         invertRTL: invertRTL,
         updateState: (state, val): void => {
             state.panelOpenState = val;


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes PXBLUE-2393 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Add new variant `within a card` in storybook.

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
![image](https://user-images.githubusercontent.com/10433274/135976160-1d945156-a11c-406a-b134-b8685474a305.png)

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- http://localhost:6006/?path=/story/components-empty-state--within-a-card
