### PR TITLE
Update styling of Score Card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Change Log
-## v6.0.1 (November 29, 2021)
+## v6.0.1 (December 1, 2021)
 
 ### Fixed
 
--   Fixed `<pxb-info-list-item>` when title contains descender letters.
+-   Fixed `<pxb-score-card>` cutting off descender letters.
 ## v6.0.0 (November 3, 2021)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
+## v6.0.1 (November 29, 2021)
 
+### Fixed
+
+-   Fixed `<pxb-info-list-item>` when title contains descender letters.
 ## v6.0.0 (November 3, 2021)
 
 ### Changed

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@brightlayer-ui/angular-components",
-    "version": "6.0.0",
+    "version": "6.0.1",
     "description": "Angular components for Brightlayer UI applications",
     "scripts": {
         "ng": "ng",

--- a/components/src/core/score-card/score-card.component.scss
+++ b/components/src/core/score-card/score-card.component.scss
@@ -25,7 +25,7 @@
 .blui-score-card-header {
     border-top-left-radius: inherit;
     border-top-right-radius: inherit;
-    height: 6rem;
+    height: 6.5rem;
     box-sizing: border-box;
     position: relative;
     * {
@@ -63,21 +63,20 @@
     }
     .blui-score-card-title {
         font-weight: 600;
-        line-height: 1;
+        line-height: 1.4;
         font-size: 1.25rem;
-        margin-bottom: 0.6rem;
+        margin-bottom: 0.25rem;
     }
     .blui-score-card-subtitle {
         font-size: 0.875rem;
         font-weight: 400;
-        margin: 0;
-        margin-bottom: 0.125rem;
-        line-height: 1.25;
+        margin: 0 0 0.25rem;
+        line-height: 1.4;
     }
     .blui-score-card-info {
         font-size: 0.875rem;
         font-weight: 300;
-        line-height: 2;
+        line-height: 1.4;
     }
 }
 


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes [359](https://github.com/pxblue/angular-component-library/issues/359).

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Adjust line-height of score card title
- Match card height with Figma design
- 

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:

<img width="598" alt="Screenshot 2021-11-26 at 2 53 26 PM" src="https://user-images.githubusercontent.com/10433274/143560738-7ef1b9aa-f0c9-4054-bd8e-bcfbd467bc56.png">

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- http://localhost:6006/?path=/story/components-score-card--with-custom-header
