### PR TITLE
Revert "Bump zone.js from 0.11.8 to 0.13.3"

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,6 @@
     "tslib": "^2.4.1",
     "typescript": "4.9.5",
     "yarn-audit-fix": "^10.0.7",
-    "zone.js": "~0.13.3"
+    "zone.js": "~0.11.8"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9267,9 +9267,9 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zone.js@~0.13.3:
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.13.3.tgz#344c24098fa047eda6427a4c7ed486e391fd67b5"
-  integrity sha512-MKPbmZie6fASC/ps4dkmIhaT5eonHkEt6eAy80K42tAm0G2W+AahLJjbfi6X9NPdciOE9GRFTTM8u2IiF6O3ww==
+zone.js@~0.11.8:
+  version "0.11.8"
+  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.11.8.tgz#40dea9adc1ad007b5effb2bfed17f350f1f46a21"
+  integrity sha512-82bctBg2hKcEJ21humWIkXRlLBBmrc3nN7DFh5LGGhcyycO2S7FN8NmdvlcKaGFDNVL4/9kFLmwmInTavdJERA==
   dependencies:
     tslib "^2.3.0"


### PR DESCRIPTION
Reverts etn-ccis/blui-angular-component-library#649

**We may need to check https://www.npmjs.com/package/zone.js?activeTab=readme#breaking-changes-since-zonejs-v0111 **